### PR TITLE
Port all the changes from vortex-alp to this crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "fastlanes",
  "itertools",
  "num-traits",
+ "rustc-hash",
  "serde",
 ]
 
@@ -90,6 +91,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "seq-macro"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = [".github/*"]
 fastlanes = "0.5"
 itertools = "0.15.0"
 num-traits = "0.2.19"
+rustc-hash = "2.1.1"
 serde = { version = "1", optional = true, features = ["derive"] }
 
 [workspace.lints.rust]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ALP: Adaptive Lossless floating-Point
 
 As modern data and analytics workloads have shifted from SQL to general-purpose programming
-languages such as Python, the amount of floating point data has grown massively. It is a
+languages such as Python, the amount of floating-point data has grown massively. It is a
 problem for modern database systems to effectively compress this data without loss of precision,
 while preserving desirable traits such as random access and auto-vectorization.
 
@@ -9,4 +9,3 @@ In 2023, [Afroozeh et al.](https://dl.acm.org/doi/pdf/10.1145/3626717) published
 a response to these issues. The code was written in [C++](https://github.com/cwida/ALP) and integrated
 into DuckDB. To ease the integration into other tools, we present a Rust implementation of both variants
 of ALP (ALP and ALP for "real doubles").
-

--- a/src/alp/mod.rs
+++ b/src/alp/mod.rs
@@ -1,12 +1,19 @@
 use itertools::Itertools;
 use num_traits::{CheckedSub, Float, PrimInt, ToPrimitive};
 use std::fmt::{Display, Formatter};
-use std::mem::size_of;
+use std::mem::{size_of, transmute, transmute_copy, MaybeUninit};
 
 const SAMPLE_SIZE: usize = 32;
 
+/// The number of values encoded per chunk.
+///
+/// [`ALPFloat::encode`] processes its input in chunks of this size and emits one entry per chunk
+/// into the returned chunk offsets, allowing consumers to find the patches belonging to a chunk
+/// without scanning the whole patch index.
+pub const ENCODE_CHUNK_SIZE: usize = 1024;
+
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Exponents {
     pub e: u8,
     pub f: u8,
@@ -25,37 +32,97 @@ mod private {
     impl Sealed for f64 {}
 }
 
-/// Encodes an array of floating-point values into an integer representation, if an exponent set is not provided it will find one.
-/// Returns the exponent set, vec of encoded values, and exceptions and their positions.
+/// Encodes an array of floating-point values, finding the best exponents if they are not provided.
+///
+/// Returns the exponents, the encoded values, the positions and values of the exceptions, and the
+/// offset into the exception positions at which each [`ENCODE_CHUNK_SIZE`] chunk begins.
+#[inline]
+#[allow(clippy::type_complexity)]
 pub fn encode<F: ALPFloat>(
     values: &[F],
     exponents: Option<Exponents>,
-) -> (Exponents, Vec<F::ALPInt>, Vec<u64>, Vec<F>) {
+) -> (Exponents, Vec<F::ALPInt>, Vec<u64>, Vec<F>, Vec<u64>) {
     F::encode(values, exponents)
 }
 
-/// Finds the best exponent pair for a given set of values, trying to minimize the number of exceptions.
+/// Encodes an array of floating-point values into a buffer owned by the caller.
+///
+/// See [`ALPFloat::encode_into`]. Prefer this over [`encode`] when the encoded values should live
+/// in your own buffer, for instance because you intend to decode them in place later.
+#[inline]
+pub fn encode_into<F: ALPFloat>(
+    values: &[F],
+    exponents: Option<Exponents>,
+    encoded: &mut [MaybeUninit<F::ALPInt>],
+    patch_indices: &mut Vec<u64>,
+    patch_values: &mut Vec<F>,
+    chunk_offsets: &mut Vec<u64>,
+) -> Exponents {
+    F::encode_into(
+        values,
+        exponents,
+        encoded,
+        patch_indices,
+        patch_values,
+        chunk_offsets,
+    )
+}
+
+/// Finds the best exponent pair for a given set of values, trying to minimize the number of
+/// exceptions.
+#[inline]
 pub fn find_best_exponents<F: ALPFloat>(values: &[F]) -> Exponents {
     F::find_best_exponents(values)
 }
 
-/// Encodes a single
-pub fn encode_single<F: ALPFloat>(value: F, exponents: Exponents) -> Result<F::ALPInt, F> {
+/// Encodes a single value, returning `None` if it does not round-trip under `exponents`.
+#[inline]
+pub fn encode_single<F: ALPFloat>(value: F, exponents: Exponents) -> Option<F::ALPInt> {
     F::encode_single(value, exponents)
 }
 
-/// Decodes an integer value to its matching floating point representation given the same exponents.
+/// Decodes an integer value to its matching floating-point representation given the same exponents.
+#[inline]
 pub fn decode_single<F: ALPFloat>(encoded: F::ALPInt, exponents: Exponents) -> F {
     F::decode_single(encoded, exponents)
 }
 
-/// Encodes a single value, it might not round-trip back it its original value
-/// # Safety
+/// Decodes a slice of encoded values into a newly allocated vector.
+#[inline]
+pub fn decode<F: ALPFloat>(encoded: &[F::ALPInt], exponents: Exponents) -> Vec<F> {
+    F::decode(encoded, exponents)
+}
+
+/// Decodes a slice of encoded values into the provided output slice.
 ///
-/// The returned value may not decode back to the original value.
+/// # Panics
+///
+/// Panics if `encoded` and `output` have different lengths.
+#[inline]
+pub fn decode_into<F: ALPFloat>(encoded: &[F::ALPInt], exponents: Exponents, output: &mut [F]) {
+    F::decode_into(encoded, exponents, output)
+}
+
+/// Decodes a slice of encoded values in-place, reinterpreting it as a slice of floats.
+#[inline]
+pub fn decode_slice_inplace<F: ALPFloat>(encoded: &mut [F::ALPInt], exponents: Exponents) {
+    F::decode_slice_inplace(encoded, exponents)
+}
+
+/// Encodes a single value without checking that it round-trips.
+///
+/// The returned value might decode to a different value than the one passed in. Use
+/// [`encode_single`] for the checked version.
 #[inline(always)]
 pub fn encode_single_unchecked<F: ALPFloat>(value: F, exponents: Exponents) -> F::ALPInt {
     F::encode_single_unchecked(value, exponents)
+}
+
+/// Widens a running `(min, max)` bound to include `value`, seeding it on the first value.
+fn update_bounds<I: Ord + Copy>(bounds: &mut Option<(I, I)>, value: I) {
+    *bounds = Some(bounds.map_or((value, value), |(min, max)| {
+        (min.min(value), max.max(value))
+    }));
 }
 
 pub trait ALPFloat: private::Sealed + Float + Display + 'static {
@@ -67,18 +134,19 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
     const F10: &'static [Self];
     const IF10: &'static [Self];
 
-    /// Round to the nearest floating integer by shifting in and out of the low precision range.
+    /// Rounds to the nearest floating integer by shifting in and out of the low precision range.
     #[inline]
     fn fast_round(self) -> Self {
         (self + Self::SWEET) - Self::SWEET
     }
 
-    /// Equivalent to calling `as` to cast the primitive float to the target integer type.
+    /// Casts the primitive float to the target integer type, equivalent to calling `as`.
     fn as_int(self) -> Self::ALPInt;
 
-    /// Convert from the integer type back to the float type using `as`.
+    /// Converts from the integer type back to the float type using `as`.
     fn from_int(n: Self::ALPInt) -> Self;
 
+    /// Compares bit-wise, so that `NaN`s and signed zeros are distinct values.
     fn is_eq(self, other: Self) -> bool;
 
     fn find_best_exponents(values: &[Self]) -> Exponents {
@@ -92,25 +160,69 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
                 .cloned()
                 .collect_vec()
         });
+        let sample = sample.as_deref().unwrap_or(values);
 
         for e in (0..Self::MAX_EXPONENT).rev() {
             for f in 0..e {
-                let (_, encoded, _, exc_patches) = Self::encode(
-                    sample.as_deref().unwrap_or(values),
-                    Some(Exponents { e, f }),
-                );
-
-                let size = Self::estimate_encoded_size(&encoded, &exc_patches);
+                let exp = Exponents { e, f };
+                let size = Self::estimate_encoded_size_for_exponents(sample, exp);
                 if size < best_nbytes {
                     best_nbytes = size;
-                    best_exp = Exponents { e, f };
+                    best_exp = exp;
                 } else if size == best_nbytes && e - f < best_exp.e - best_exp.f {
-                    best_exp = Exponents { e, f };
+                    best_exp = exp;
                 }
             }
         }
 
         best_exp
+    }
+
+    /// Estimates the encoded size of `values` under `exponents`, matching a full
+    /// [`Self::encode`] plus [`Self::estimate_encoded_size`] but without the per-candidate
+    /// allocations.
+    fn estimate_encoded_size_for_exponents(values: &[Self], exponents: Exponents) -> usize {
+        // `kept` is the (min, max) over values that round-trip exactly (kept inline by `encode`);
+        // `all` is the (min, max) over every encoded value. `encode` fills patched slots in-range,
+        // so its emitted range is `kept`, except with all values patched (no fill), where `all`
+        // wins.
+        let mut kept: Option<(Self::ALPInt, Self::ALPInt)> = None;
+        let mut all: Option<(Self::ALPInt, Self::ALPInt)> = None;
+        let mut patch_count = 0usize;
+
+        for &value in values {
+            let encoded = Self::encode_single_unchecked(value, exponents);
+            update_bounds(&mut all, encoded);
+            if Self::decode_single(encoded, exponents).is_eq(value) {
+                update_bounds(&mut kept, encoded);
+            } else {
+                patch_count += 1;
+            }
+        }
+
+        let range = if patch_count == values.len() {
+            all
+        } else {
+            kept
+        };
+
+        let bits_per_encoded = range
+            .and_then(|(min, max)| max.checked_sub(&min))
+            .and_then(|range_size| range_size.to_u64())
+            .and_then(|range_size| {
+                range_size
+                    .checked_ilog2()
+                    .map(|bits| (bits + 1) as usize)
+                    .or(Some(0))
+            })
+            .unwrap_or(size_of::<Self::ALPInt>() * 8);
+
+        let encoded_bytes = (values.len() * bits_per_encoded).div_ceil(8);
+        // Each patch is a value plus a position. In practice, patch positions are in
+        // [0, u16::MAX] because of how we chunk.
+        let patch_bytes = patch_count * (size_of::<Self>() + size_of::<u16>());
+
+        encoded_bytes + patch_bytes
     }
 
     #[inline]
@@ -119,7 +231,8 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
             .iter()
             .minmax()
             .into_option()
-            // estimating bits per encoded value assuming frame-of-reference + bitpacking-without-patches
+            // Estimate the bits per encoded value, assuming frame-of-reference plus
+            // bit-packing without patches.
             .and_then(|(min, max)| max.checked_sub(min))
             .and_then(|range_size: <Self as ALPFloat>::ALPInt| range_size.to_u64())
             .and_then(|range_size| {
@@ -131,69 +244,180 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
             .unwrap_or(size_of::<Self::ALPInt>() * 8);
 
         let encoded_bytes = (encoded.len() * bits_per_encoded).div_ceil(8);
-        // each patch is a value + a position
-        // in practice, patch positions are in [0, u16::MAX] because of how we chunk
+        // Each patch is a value plus a position. In practice, patch positions are in
+        // [0, u16::MAX] because of how we chunk.
         let patch_bytes = patches.len() * (size_of::<Self>() + size_of::<u16>());
 
         encoded_bytes + patch_bytes
     }
 
+    /// Encodes `values`, finding the best exponents if they are not provided.
+    ///
+    /// Returns the exponents, the encoded values, the positions and values of the exceptions, and
+    /// the offset into the exception positions at which each [`ENCODE_CHUNK_SIZE`] chunk begins.
+    ///
+    /// Use [`Self::encode_into`] if the encoded values should land in a buffer you own, which is
+    /// what you want if you intend to decode them in place later.
+    #[allow(clippy::type_complexity)]
     fn encode(
         values: &[Self],
         exponents: Option<Exponents>,
-    ) -> (Exponents, Vec<Self::ALPInt>, Vec<u64>, Vec<Self>) {
-        let exp = exponents.unwrap_or_else(|| Self::find_best_exponents(values));
-
+    ) -> (Exponents, Vec<Self::ALPInt>, Vec<u64>, Vec<Self>, Vec<u64>) {
         let mut encoded_output = Vec::with_capacity(values.len());
-        let mut patch_indices = Vec::new();
-        let mut patch_values = Vec::new();
+
+        // Estimate capacity to be one patch per 32 values.
+        let mut patch_indices = Vec::with_capacity(values.len() / 32);
+        let mut patch_values = Vec::with_capacity(values.len() / 32);
+
+        // There's exactly one offset per chunk.
+        let mut chunk_offsets = Vec::with_capacity(values.len().div_ceil(ENCODE_CHUNK_SIZE));
+
+        let exp = Self::encode_into(
+            values,
+            exponents,
+            &mut encoded_output.spare_capacity_mut()[..values.len()],
+            &mut patch_indices,
+            &mut patch_values,
+            &mut chunk_offsets,
+        );
+
+        // SAFETY: `encode_into` initializes exactly `values.len()` elements.
+        unsafe { encoded_output.set_len(values.len()) };
+
+        (
+            exp,
+            encoded_output,
+            patch_indices,
+            patch_values,
+            chunk_offsets,
+        )
+    }
+
+    /// Encodes `values` into an output buffer owned by the caller, returning the exponents used.
+    ///
+    /// `encoded` must hold exactly `values.len()` elements, all of which are initialized on
+    /// return. The exception positions and values, plus one offset into the exception positions
+    /// per [`ENCODE_CHUNK_SIZE`] chunk, are appended to the three vectors, which must start empty.
+    ///
+    /// This exists so that the encoded values can be written straight into a buffer the caller
+    /// controls (an arena, an aligned buffer, or anything else it will later decode in place),
+    /// rather than into a `Vec` that has to be adopted or copied afterwards.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `encoded` is not the same length as `values`, or if any of `patch_indices`,
+    /// `patch_values` or `chunk_offsets` is non-empty.
+    fn encode_into(
+        values: &[Self],
+        exponents: Option<Exponents>,
+        encoded: &mut [MaybeUninit<Self::ALPInt>],
+        patch_indices: &mut Vec<u64>,
+        patch_values: &mut Vec<Self>,
+        chunk_offsets: &mut Vec<u64>,
+    ) -> Exponents {
+        assert_eq!(
+            encoded.len(),
+            values.len(),
+            "encode_into: output buffer must hold exactly one element per value"
+        );
+        assert!(
+            patch_indices.is_empty() && patch_values.is_empty() && chunk_offsets.is_empty(),
+            "encode_into: patch and chunk offset outputs must start empty"
+        );
+
+        let exp = exponents.unwrap_or_else(|| Self::find_best_exponents(values));
         let mut fill_value: Option<Self::ALPInt> = None;
 
-        // this is intentionally branchless
-        // we batch this into 32KB of values at a time to make it more L1 cache friendly
-        let encode_chunk_size: usize = (32 << 10) / size_of::<Self::ALPInt>();
-        for chunk in values.chunks(encode_chunk_size) {
+        // This is intentionally branchless.
+        for (chunk_idx, chunk) in values.chunks(ENCODE_CHUNK_SIZE).enumerate() {
+            chunk_offsets.push(patch_indices.len() as u64);
             encode_chunk_unchecked(
                 chunk,
+                chunk_idx * ENCODE_CHUNK_SIZE,
                 exp,
-                &mut encoded_output,
-                &mut patch_indices,
-                &mut patch_values,
+                encoded,
+                patch_indices,
+                patch_values,
                 &mut fill_value,
             );
         }
 
-        (exp, encoded_output, patch_indices, patch_values)
+        exp
     }
 
+    #[inline]
     fn encode_above(value: Self, exponents: Exponents) -> Self::ALPInt {
         (value * Self::F10[exponents.e as usize] * Self::IF10[exponents.f as usize])
             .ceil()
             .as_int()
     }
 
+    #[inline]
     fn encode_below(value: Self, exponents: Exponents) -> Self::ALPInt {
         (value * Self::F10[exponents.e as usize] * Self::IF10[exponents.f as usize])
             .floor()
             .as_int()
     }
 
+    /// Encodes a single value, returning `None` if it does not round-trip under `exponents`.
     #[inline]
-    fn encode_single(value: Self, exponents: Exponents) -> Result<Self::ALPInt, Self> {
+    fn encode_single(value: Self, exponents: Exponents) -> Option<Self::ALPInt> {
         let encoded = Self::encode_single_unchecked(value, exponents);
         let decoded = Self::decode_single(encoded, exponents);
         if decoded.is_eq(value) {
-            return Ok(encoded);
+            return Some(encoded);
         }
-        Err(value)
+        None
     }
 
+    /// Decodes `encoded` into a newly allocated vector.
     #[inline]
+    fn decode(encoded: &[Self::ALPInt], exponents: Exponents) -> Vec<Self> {
+        let mut values = Vec::with_capacity(encoded.len());
+        for encoded in encoded {
+            values.push(Self::decode_single(*encoded, exponents));
+        }
+        values
+    }
+
+    /// Decodes `encoded` into `output`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `encoded` and `output` have different lengths.
+    #[inline]
+    fn decode_into(encoded: &[Self::ALPInt], exponents: Exponents, output: &mut [Self]) {
+        assert_eq!(encoded.len(), output.len());
+
+        for i in 0..encoded.len() {
+            output[i] = Self::decode_single(encoded[i], exponents)
+        }
+    }
+
+    /// Decodes `encoded` in-place, reinterpreting the slice as floats of the same width.
+    #[inline]
+    fn decode_slice_inplace(encoded: &mut [Self::ALPInt], exponents: Exponents) {
+        // SAFETY: `Self` and `Self::ALPInt` have the same size and alignment (f32/i32, f64/i64),
+        // and every bit pattern is valid for both.
+        let decoded: &mut [Self] = unsafe { transmute(encoded) };
+        decoded.iter_mut().for_each(|v| {
+            // SAFETY: as above, we're reading back the integer we have not yet overwritten.
+            *v = Self::decode_single(
+                unsafe { transmute_copy::<Self, Self::ALPInt>(v) },
+                exponents,
+            )
+        })
+    }
+
+    #[inline(always)]
     fn decode_single(encoded: Self::ALPInt, exponents: Exponents) -> Self {
         Self::from_int(encoded) * Self::F10[exponents.f as usize] * Self::IF10[exponents.e as usize]
     }
 
-    /// Encodes a single value, it might not round-trip back it its original value
+    /// Encodes a single value without checking that it round-trips.
+    ///
+    /// The returned value might decode to a different value than the one passed in. Use
+    /// [`Self::encode_single`] for the checked version.
     #[inline(always)]
     fn encode_single_unchecked(value: Self, exponents: Exponents) -> Self::ALPInt {
         (value * Self::F10[exponents.e as usize] * Self::IF10[exponents.f as usize])
@@ -202,60 +426,74 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
     }
 }
 
+/// Encodes one chunk into `encoded_output`, which covers the whole array: elements before
+/// `num_prev_encoded` are already initialized, this chunk initializes the next `chunk.len()`.
 fn encode_chunk_unchecked<T: ALPFloat>(
     chunk: &[T],
+    num_prev_encoded: usize,
     exp: Exponents,
-    encoded_output: &mut Vec<T::ALPInt>,
+    encoded_output: &mut [MaybeUninit<T::ALPInt>],
     patch_indices: &mut Vec<u64>,
     patch_values: &mut Vec<T>,
     fill_value: &mut Option<T::ALPInt>,
 ) {
-    let num_prev_encoded = encoded_output.len();
     let num_prev_patches = patch_indices.len();
     assert_eq!(patch_indices.len(), patch_values.len());
     let has_filled = fill_value.is_some();
 
-    // encode the chunk, counting the number of patches
+    // Encode the chunk, counting the number of patches.
     let mut chunk_patch_count = 0;
-    encoded_output.extend(chunk.iter().map(|&v| {
-        let encoded = encode_single_unchecked(v, exp);
+    for (output, &v) in encoded_output[num_prev_encoded..][..chunk.len()]
+        .iter_mut()
+        .zip(chunk)
+    {
+        let encoded = T::encode_single_unchecked(v, exp);
         let decoded = T::decode_single(encoded, exp);
         let neq = !decoded.is_eq(v) as usize;
         chunk_patch_count += neq;
-        encoded
-    }));
+        output.write(encoded);
+    }
     let chunk_patch_count = chunk_patch_count; // immutable hereafter
-    assert_eq!(encoded_output.len(), num_prev_encoded + chunk.len());
+
+    let encoded_len = num_prev_encoded + chunk.len();
+    // SAFETY: every element below `encoded_len` has been initialized, by this call for the values
+    // of this chunk and by the preceding calls for everything before it.
+    let encoded_output: &mut [T::ALPInt] = unsafe {
+        std::slice::from_raw_parts_mut(encoded_output.as_mut_ptr().cast::<T::ALPInt>(), encoded_len)
+    };
 
     if chunk_patch_count > 0 {
-        // we need to gather the patches for this chunk
-        // preallocate space for the patches (plus one because our loop may attempt to write one past the end)
+        // We need to gather the patches for this chunk. Preallocate space for them, plus one
+        // because our loop may attempt to write one past the end.
         patch_indices.reserve(chunk_patch_count + 1);
         patch_values.reserve(chunk_patch_count + 1);
 
-        // record the patches in this chunk
+        // Record the patches in this chunk.
         let patch_indices_mut = patch_indices.spare_capacity_mut();
         let patch_values_mut = patch_values.spare_capacity_mut();
         let mut chunk_patch_index = 0;
-        for i in num_prev_encoded..encoded_output.len() {
+        for i in num_prev_encoded..encoded_len {
             let decoded = T::decode_single(encoded_output[i], exp);
-            // write() is only safe to call more than once because the values are primitive (i.e., Drop is a no-op)
+            // `write()` is only safe to call more than once because the values are primitive,
+            // i.e. `Drop` is a no-op.
             patch_indices_mut[chunk_patch_index].write(i as u64);
             patch_values_mut[chunk_patch_index].write(chunk[i - num_prev_encoded]);
             chunk_patch_index += !decoded.is_eq(chunk[i - num_prev_encoded]) as usize;
         }
         assert_eq!(chunk_patch_index, chunk_patch_count);
+        // SAFETY: we just initialized `chunk_patch_count` elements in the spare capacity of both
+        // vectors, which we reserved above.
         unsafe {
             patch_indices.set_len(num_prev_patches + chunk_patch_count);
             patch_values.set_len(num_prev_patches + chunk_patch_count);
         }
     }
 
-    // find the first successfully encoded value (i.e., not patched)
-    // this is our fill value for missing values
-    if fill_value.is_none() && (num_prev_encoded + chunk_patch_count < encoded_output.len()) {
+    // Find the first successfully encoded value, i.e. one that is not patched. This is our fill
+    // value for missing values.
+    if fill_value.is_none() && (num_prev_encoded + chunk_patch_count < encoded_len) {
         assert_eq!(num_prev_encoded, num_prev_patches);
-        for i in num_prev_encoded..encoded_output.len() {
+        for i in num_prev_encoded..encoded_len {
             if i >= patch_indices.len() || patch_indices[i] != i as u64 {
                 *fill_value = Some(encoded_output[i]);
                 break;
@@ -263,10 +501,10 @@ fn encode_chunk_unchecked<T: ALPFloat>(
         }
     }
 
-    // replace the patched values in the encoded array with the fill value
-    // for better downstream compression
+    // Replace the patched values in the encoded array with the fill value, for better downstream
+    // compression.
     if let Some(fill_value) = fill_value {
-        // handle the edge case where the first N >= 1 chunks are all patches
+        // Handle the edge case where the first N >= 1 chunks are all patches.
         let start_patch = if !has_filled { 0 } else { num_prev_patches };
         for patch_idx in &patch_indices[start_patch..] {
             encoded_output[*patch_idx as usize] = *fill_value;
@@ -318,6 +556,7 @@ impl ALPFloat for f32 {
         n as _
     }
 
+    #[inline(always)]
     fn is_eq(self, other: Self) -> bool {
         self.to_bits() == other.to_bits()
     }
@@ -393,6 +632,7 @@ impl ALPFloat for f64 {
         n as _
     }
 
+    #[inline(always)]
     fn is_eq(self, other: Self) -> bool {
         self.to_bits() == other.to_bits()
     }
@@ -402,12 +642,168 @@ impl ALPFloat for f64 {
 mod tests {
     use super::*;
 
+    // The allocation-free estimate must match a full encode plus estimate for every candidate
+    // exponent pair, so that `find_best_exponents` picks the same exponents and compression is
+    // unchanged.
+    fn check_estimate_matches<T: ALPFloat>(values: &[T]) {
+        for e in 0..T::MAX_EXPONENT {
+            for f in 0..e {
+                let exp = Exponents { e, f };
+                let lightweight = T::estimate_encoded_size_for_exponents(values, exp);
+                let (_, encoded, _, patches, _) = T::encode(values, Some(exp));
+                let full = T::estimate_encoded_size(&encoded, &patches);
+                assert_eq!(
+                    lightweight,
+                    full,
+                    "mismatch at e={e}, f={f}, len={}",
+                    values.len()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn estimate_for_exponents_matches_full_encode() {
+        // Clean 2-decimal values (mostly kept), repeating decimals (many patches), large
+        // magnitudes, constants, and a single element.
+        let mut f64s: Vec<f64> = (0..200).map(|i| i as f64 / 100.0).collect();
+        f64s.extend((0..60).map(|i| i as f64 / 7.0));
+        f64s.extend([1e17, -1e17, 0.0, 123.0]);
+        check_estimate_matches(&f64s);
+        check_estimate_matches::<f64>(&[123.456; 5]);
+        check_estimate_matches::<f64>(&[42.0]);
+        // Every value patches at every exponent -> exercises the all-patched branch.
+        check_estimate_matches::<f64>(&[1.0 / 3.0; 8]);
+
+        let mut f32s: Vec<f32> = (0..200).map(|i| i as f32 / 100.0).collect();
+        f32s.extend((0..60).map(|i| i as f32 / 7.0));
+        f32s.extend([1e9, -1e9, 0.0, 123.0]);
+        check_estimate_matches(&f32s);
+        check_estimate_matches::<f32>(&[1.0 / 3.0; 8]);
+    }
+
     #[test]
     fn non_finite_numbers() {
         let original = vec![0.0f32, -0.0, f32::NAN, f32::NEG_INFINITY, f32::INFINITY];
-        let (_, encoded, patch_idx, _) = encode(&original, None);
+        let (_, encoded, patch_idx, _, chunk_offsets) = encode(&original, None);
 
         assert_eq!(patch_idx, vec![1, 2, 3, 4]);
         assert_eq!(encoded, vec![0, 0, 0, 0, 0]);
+        assert_eq!(chunk_offsets, vec![0]);
+    }
+
+    #[test]
+    fn round_trip() {
+        let original = vec![1.234f64; 1025];
+        let (exponents, encoded, patch_idx, patch_values, chunk_offsets) = encode(&original, None);
+
+        assert_eq!(exponents.e - exponents.f, 3);
+        assert_eq!(encoded, vec![1234i64; 1025]);
+        assert!(patch_idx.is_empty());
+        assert!(patch_values.is_empty());
+        assert_eq!(chunk_offsets, vec![0, 0]);
+
+        assert_eq!(decode::<f64>(&encoded, exponents), original);
+    }
+
+    #[test]
+    fn decode_matches_decode_single() {
+        let original = vec![1.234f32, 5.678, -9.0, 0.001];
+        let (exponents, encoded, ..) = encode(&original, None);
+
+        let decoded = decode::<f32>(&encoded, exponents);
+        assert_eq!(decoded, original);
+
+        let mut into = vec![0f32; encoded.len()];
+        decode_into::<f32>(&encoded, exponents, &mut into);
+        assert_eq!(into, original);
+
+        let mut inplace = encoded.clone();
+        decode_slice_inplace::<f32>(&mut inplace, exponents);
+        // SAFETY: `i32` and `f32` have the same layout, and the slice now holds decoded floats.
+        let inplace: &[f32] = unsafe { transmute(inplace.as_slice()) };
+        assert_eq!(inplace, original);
+    }
+
+    #[test]
+    fn chunk_offsets_are_per_chunk() {
+        let mut values = vec![1.0f64; 3 * ENCODE_CHUNK_SIZE];
+        values[1023] = std::f64::consts::PI;
+        values[1024] = std::f64::consts::E;
+        values[1025] = std::f64::consts::PI;
+
+        let (_, _, patch_idx, _, chunk_offsets) = encode(&values, None);
+        assert_eq!(patch_idx, vec![1023, 1024, 1025]);
+        assert_eq!(chunk_offsets, vec![0, 1, 3]);
+    }
+
+    #[test]
+    fn chunk_offsets_with_empty_chunks() {
+        let mut values = vec![1.0f64; 3 * ENCODE_CHUNK_SIZE];
+        values[0] = std::f64::consts::PI;
+        values[2048] = std::f64::consts::E;
+
+        let (_, _, patch_idx, _, chunk_offsets) = encode(&values, None);
+        assert_eq!(patch_idx, vec![0, 2048]);
+        assert_eq!(chunk_offsets, vec![0, 1, 1]);
+    }
+
+    #[test]
+    fn encode_into_matches_encode() {
+        // Also covers the multi-chunk path, where a chunk writes into the middle of the output.
+        let mut values = vec![1.234f64; 2 * ENCODE_CHUNK_SIZE + 3];
+        values[7] = std::f64::consts::PI;
+        values[1500] = std::f64::consts::E;
+        values[2050] = f64::NAN;
+
+        let (exponents, encoded, patch_indices, patch_values, chunk_offsets) =
+            encode(&values, None);
+
+        let mut into_encoded: Vec<i64> = Vec::with_capacity(values.len());
+        let mut into_patch_indices = Vec::new();
+        let mut into_patch_values = Vec::new();
+        let mut into_chunk_offsets = Vec::new();
+        let into_exponents = encode_into(
+            &values,
+            None,
+            &mut into_encoded.spare_capacity_mut()[..values.len()],
+            &mut into_patch_indices,
+            &mut into_patch_values,
+            &mut into_chunk_offsets,
+        );
+        // SAFETY: `encode_into` initializes every element of the output.
+        unsafe { into_encoded.set_len(values.len()) };
+
+        assert_eq!(into_exponents, exponents);
+        assert_eq!(into_encoded, encoded);
+        assert_eq!(into_patch_indices, patch_indices);
+        assert!(into_patch_values
+            .iter()
+            .zip(&patch_values)
+            .all(|(a, b)| a.is_eq(*b)));
+        assert_eq!(into_chunk_offsets, chunk_offsets);
+    }
+
+    #[test]
+    #[should_panic(expected = "output buffer must hold exactly one element per value")]
+    fn encode_into_rejects_wrong_sized_output() {
+        let values = vec![1.234f64; 4];
+        let mut encoded: Vec<i64> = Vec::with_capacity(2);
+        encode_into(
+            &values,
+            None,
+            &mut encoded.spare_capacity_mut()[..2],
+            &mut Vec::new(),
+            &mut Vec::new(),
+            &mut Vec::new(),
+        );
+    }
+
+    #[test]
+    fn encode_single_round_trips() {
+        let exponents = Exponents { e: 16, f: 13 };
+        assert_eq!(encode_single(1.234f64, exponents), Some(1234));
+        assert_eq!(encode_single(std::f64::consts::PI, exponents), None);
+        assert_eq!(decode_single::<f64>(1234, exponents), 1.234);
     }
 }

--- a/src/alp/mod.rs
+++ b/src/alp/mod.rs
@@ -113,7 +113,7 @@ pub fn decode_slice_inplace<F: ALPFloat>(encoded: &mut [F::ALPInt], exponents: E
 ///
 /// The returned value might decode to a different value than the one passed in. Use
 /// [`encode_single`] for the checked version.
-#[inline(always)]
+#[inline]
 pub fn encode_single_unchecked<F: ALPFloat>(value: F, exponents: Exponents) -> F::ALPInt {
     F::encode_single_unchecked(value, exponents)
 }
@@ -409,7 +409,7 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
         })
     }
 
-    #[inline(always)]
+    #[inline]
     fn decode_single(encoded: Self::ALPInt, exponents: Exponents) -> Self {
         Self::from_int(encoded) * Self::F10[exponents.f as usize] * Self::IF10[exponents.e as usize]
     }
@@ -418,7 +418,7 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
     ///
     /// The returned value might decode to a different value than the one passed in. Use
     /// [`Self::encode_single`] for the checked version.
-    #[inline(always)]
+    #[inline]
     fn encode_single_unchecked(value: Self, exponents: Exponents) -> Self::ALPInt {
         (value * Self::F10[exponents.e as usize] * Self::IF10[exponents.f as usize])
             .fast_round()
@@ -546,17 +546,17 @@ impl ALPFloat for f32 {
         0.0000000001, // 10^-10
     ];
 
-    #[inline(always)]
+    #[inline]
     fn as_int(self) -> Self::ALPInt {
         self as _
     }
 
-    #[inline(always)]
+    #[inline]
     fn from_int(n: Self::ALPInt) -> Self {
         n as _
     }
 
-    #[inline(always)]
+    #[inline]
     fn is_eq(self, other: Self) -> bool {
         self.to_bits() == other.to_bits()
     }
@@ -622,17 +622,17 @@ impl ALPFloat for f64 {
         0.00000000000000000000001, // 10^-23
     ];
 
-    #[inline(always)]
+    #[inline]
     fn as_int(self) -> Self::ALPInt {
         self as _
     }
 
-    #[inline(always)]
+    #[inline]
     fn from_int(n: Self::ALPInt) -> Self {
         n as _
     }
 
-    #[inline(always)]
+    #[inline]
     fn is_eq(self, other: Self) -> bool {
         self.to_bits() == other.to_bits()
     }

--- a/src/alp_rd/bitpack.rs
+++ b/src/alp_rd/bitpack.rs
@@ -6,13 +6,13 @@ use fastlanes::BitPacking;
 /// Logically, a `PackedVec<T>` is a vector containing values of type `T`.
 ///
 /// Physically, the values are stored bit-packed down to a given width. They can be individually
-/// accessed by performing single unpacking operation.
+/// accessed by performing a single unpacking operation.
 pub struct PackedVec<T> {
     values: Vec<T>,
     packed_width: usize,
 }
 
-/// Bitpack a slice of primitives down to the given width using the FastLanes layout.
+/// Bitpacks a slice of primitives down to the given width using the FastLanes layout.
 pub(crate) fn fastlanes_pack<T: BitPacking>(array: &[T], bit_width: usize) -> Vec<T> {
     if bit_width == 0 {
         return Vec::new();
@@ -22,11 +22,11 @@ pub(crate) fn fastlanes_pack<T: BitPacking>(array: &[T], bit_width: usize) -> Ve
     let num_chunks = array.len().div_ceil(1024);
     let num_full_chunks = array.len() / 1024;
     let packed_len = 128 * bit_width / size_of::<T>();
-    // packed_len says how many values of size T we're going to include.
-    // 1024 * bit_width / 8 == the number of bytes we're going to get.
-    // then we divide by the size of T to get the number of elements.
+    // `packed_len` says how many values of size T we're going to include:
+    // 1024 * bit_width / 8 is the number of bytes we're going to get, which we then divide by the
+    // size of T to get the number of elements.
 
-    // Allocate a result byte array.
+    // Allocate the result vector.
     let mut output = Vec::<T>::with_capacity(num_chunks * packed_len);
 
     // Loop over all but the last chunk.
@@ -77,7 +77,8 @@ pub(crate) fn fastlanes_unpack<T: BitPacking>(
     }
 
     // How many fastlanes vectors we will process.
-    // Packed array might not start at 0 when the array is sliced. Offset is guaranteed to be < 1024.
+    // The packed array might not start at 0 when the array is sliced. The offset is guaranteed
+    // to be < 1024.
     let num_chunks = (offset + length).div_ceil(1024);
     let elems_per_chunk = 128 * bit_width / size_of::<T>();
     assert_eq!(
@@ -88,10 +89,11 @@ pub(crate) fn fastlanes_unpack<T: BitPacking>(
         num_chunks * elems_per_chunk
     );
 
-    // Allocate a result vector.
+    // Allocate the result vector.
     let mut output = Vec::with_capacity(num_chunks * 1024 - offset);
 
-    // Handle first chunk if offset is non 0. We have to decode the chunk and skip first offset elements
+    // Handle the first chunk if the offset is non-zero. We have to decode the chunk and skip the
+    // first `offset` elements.
     let first_full_chunk = if offset != 0 {
         let chunk: &[T] = &packed[0..elems_per_chunk];
         let mut decoded = [T::zero(); 1024];
@@ -112,12 +114,12 @@ pub(crate) fn fastlanes_unpack<T: BitPacking>(
         }
     });
 
-    // The final chunk may have had padding
+    // The final chunk may have had padding.
     output.truncate(length);
 
-    // For small vectors, the overhead of rounding up is more noticable.
-    // Shrink to fit may or may not reallocate depending on the implementation.
-    // But for very small vectors, the reallocation is cheap enough even if it does happen.
+    // For small vectors, the overhead of rounding up is more noticeable. Shrinking to fit may or
+    // may not reallocate depending on the implementation, but for very small vectors the
+    // reallocation is cheap enough even if it does happen.
     if output.len() < 1024 {
         output.shrink_to_fit();
     }
@@ -132,7 +134,7 @@ pub(crate) fn fastlanes_unpack<T: BitPacking>(
     output
 }
 
-// TODO: add fastlanes_unpack_dict that fuses dictionary lookup with unpacking.
+// TODO: add a `fastlanes_unpack_dict` that fuses dictionary lookup with unpacking.
 
 #[cfg(test)]
 mod test {

--- a/src/alp_rd/mod.rs
+++ b/src/alp_rd/mod.rs
@@ -2,25 +2,26 @@ mod bitpack;
 
 use crate::Exceptions;
 use fastlanes::BitPacking;
-use num_traits::{Float, One, PrimInt, Unsigned};
-use std::collections::HashMap;
+use num_traits::{Float, One, PrimInt, Unsigned, Zero};
+use rustc_hash::FxHashMap;
 use std::marker::PhantomData;
 use std::ops::{Shl, Shr};
 
-macro_rules! bit_width {
-    ($value:expr) => {
-        if $value == 0 {
-            1
-        } else {
-            $value.ilog2().wrapping_add(1) as usize
-        }
-    };
+/// Returns the number of bits required to represent `value`, with a minimum of one.
+#[inline]
+pub const fn bit_width(value: u64) -> u8 {
+    if value == 0 {
+        1
+    } else {
+        value.ilog2().wrapping_add(1) as u8
+    }
 }
 
-/// Max number of bits to cut from the MSB section of each float.
-const CUT_LIMIT: usize = 16;
+/// Maximum number of bits to cut from the MSB section of each float.
+pub const CUT_LIMIT: usize = 16;
 
-const MAX_DICT_SIZE: u8 = 8;
+/// Maximum number of entries in the left-parts dictionary.
+pub const MAX_DICT_SIZE: u8 = 8;
 
 mod private {
     pub trait Sealed {}
@@ -29,10 +30,10 @@ mod private {
     impl Sealed for f64 {}
 }
 
-/// Main trait for ALP-RD encodable floating point numbers.
+/// Main trait for ALP-RD encodable floating-point numbers.
 ///
-/// Like the paper, we limit this to the IEEE7 754 single-precision (`f32`) and double-precision
-/// (`f64`) floating point types.
+/// Like the paper, we limit this to the IEEE 754 single-precision (`f32`) and double-precision
+/// (`f64`) floating-point types.
 pub trait ALPRDFloat: private::Sealed + Float {
     /// The unsigned integer type with the same bit-width as the floating-point type.
     type UINT: PrimInt + BitPacking + Unsigned + One;
@@ -40,34 +41,38 @@ pub trait ALPRDFloat: private::Sealed + Float {
     /// Number of bits the value occupies in registers.
     const BITS: usize = size_of::<Self>() * 8;
 
-    /// Bit-wise transmute from the unsigned integer type to the floating-point type.
+    /// Transmutes bit-wise from the unsigned integer type to the floating-point type.
     fn from_bits(bits: Self::UINT) -> Self;
 
-    /// Bit-wise transmute into the unsigned integer type.
+    /// Transmutes bit-wise into the unsigned integer type.
     fn to_bits(value: Self) -> Self::UINT;
 
-    /// Truncating conversion from the unsigned integer type to `u16`.
+    /// Converts the unsigned integer type to `u16`, truncating.
     fn to_u16(bits: Self::UINT) -> u16;
 
-    /// Type-widening conversion from `u16` to the unsigned integer type.
+    /// Converts a `u16` to the unsigned integer type, widening.
     fn from_u16(value: u16) -> Self::UINT;
 }
 
 impl ALPRDFloat for f64 {
     type UINT = u64;
 
+    #[inline(always)]
     fn from_bits(bits: Self::UINT) -> Self {
         f64::from_bits(bits)
     }
 
+    #[inline(always)]
     fn to_bits(value: Self) -> Self::UINT {
         value.to_bits()
     }
 
+    #[inline(always)]
     fn to_u16(bits: Self::UINT) -> u16 {
         bits as u16
     }
 
+    #[inline(always)]
     fn from_u16(value: u16) -> Self::UINT {
         value as u64
     }
@@ -76,18 +81,22 @@ impl ALPRDFloat for f64 {
 impl ALPRDFloat for f32 {
     type UINT = u32;
 
+    #[inline(always)]
     fn from_bits(bits: Self::UINT) -> Self {
         f32::from_bits(bits)
     }
 
+    #[inline(always)]
     fn to_bits(value: Self) -> Self::UINT {
         value.to_bits()
     }
 
+    #[inline(always)]
     fn to_u16(bits: Self::UINT) -> u16 {
         bits as u16
     }
 
+    #[inline(always)]
     fn from_u16(value: u16) -> Self::UINT {
         value as u32
     }
@@ -98,17 +107,18 @@ impl ALPRDFloat for f32 {
 /// The encoder calculates its parameters from a single sample of floating-point values,
 /// and then can be applied to many vectors.
 ///
-/// ALP-RD uses the algorithm outlined in Section 3.4 of the paper. The crux of it is that the front
-/// (most significant) bits of many double vectors tend to be  the same, i.e. most doubles in a
-/// vector often use the same exponent and front bits. Compression proceeds by finding the best
-/// prefix of up to 16 bits that can be collapsed into a dictionary of
-/// up to 8 elements. Each double can then be broken into the front/left `L` bits, which neatly
-/// bit-packs down to 1-3 bits per element (depending on the actual dictionary size).
-/// The remaining `R` bits naturally bit-pack.
+/// ALP-RD uses the algorithm outlined in Section 3.4 of the paper. The crux of it is that the
+/// front (most significant) bits of many double vectors tend to be the same, i.e. most doubles in
+/// a vector often use the same exponent and front bits. Compression proceeds by finding the best
+/// prefix of up to 16 bits that can be collapsed into a dictionary of up to 8 elements. Each
+/// double can then be broken into the front/left `L` bits, which neatly bit-packs down to 1-3 bits
+/// per element (depending on the actual dictionary size). The remaining `R` bits naturally
+/// bit-pack.
 ///
 /// In the ideal case, this scheme allows us to store a sequence of doubles in 49 bits-per-value.
 ///
-/// Our implementation draws on the MIT-licensed [C++ implementation] provided by the original authors.
+/// Our implementation draws on the MIT-licensed [C++ implementation] provided by the original
+/// authors.
 ///
 /// [C++ implementation]: https://github.com/cwida/ALP/blob/main/include/alp/rd.hpp
 pub struct RDEncoder {
@@ -118,19 +128,22 @@ pub struct RDEncoder {
 
 /// The "cut" ALP-RD vector.
 ///
-/// ALP-RD will take a vector of input floating point numbers into a left-parts and a right-parts,
-/// split along a cut-point. The left and right values are held separately.
+/// ALP-RD splits a vector of input floating-point numbers into left parts and right parts,
+/// divided at a cut point. The left and right values are held separately.
 pub struct Split<F, U> {
-    /// Bit-packed left parts
+    /// Dictionary codes for the left parts.
     left_parts: Vec<u16>,
 
-    /// Exceptions for the left_parts that could not be dictionary encoded.
+    /// Exceptions for the `left_parts` that could not be dictionary encoded.
     left_exceptions: Exceptions<u16>,
 
     /// Dictionary for encoding the `left_parts`.
     left_dict: Vec<u16>,
 
-    /// Bit-packed right parts
+    /// Bit-width for the `left_parts` codes.
+    left_parts_bit_width: u8,
+
+    /// The right parts.
     right_parts: Vec<U>,
 
     /// Bit-width for the `right_parts` component.
@@ -140,7 +153,7 @@ pub struct Split<F, U> {
 }
 
 impl<T, U> Split<T, U> {
-    /// Consume the parts of the result.
+    /// Consumes the parts of the result.
     pub fn into_parts(self) -> (Vec<u16>, Vec<u16>, Exceptions<u16>, Vec<U>, u8) {
         (
             self.left_parts,
@@ -151,7 +164,32 @@ impl<T, U> Split<T, U> {
         )
     }
 
-    /// Access the bit-width for just the right parts.
+    /// Returns the dictionary codes of the left parts.
+    pub fn left_parts(&self) -> &[u16] {
+        &self.left_parts
+    }
+
+    /// Returns the dictionary used to encode the left parts.
+    pub fn left_dict(&self) -> &[u16] {
+        &self.left_dict
+    }
+
+    /// Returns the exceptions of the left parts.
+    pub fn left_exceptions(&self) -> &Exceptions<u16> {
+        &self.left_exceptions
+    }
+
+    /// Returns the right parts.
+    pub fn right_parts(&self) -> &[U] {
+        &self.right_parts
+    }
+
+    /// Returns the bit-width of just the left parts, i.e. the width of the dictionary codes.
+    pub fn left_parts_bit_width(&self) -> u8 {
+        self.left_parts_bit_width
+    }
+
+    /// Returns the bit-width of just the right parts.
     pub fn right_parts_bit_width(&self) -> u8 {
         self.right_parts_bit_width
     }
@@ -161,7 +199,7 @@ impl<F, U> Split<F, U>
 where
     F: ALPRDFloat<UINT = U>,
 {
-    /// Decode back into a vector of the floating point type.
+    /// Decodes back into a vector of the floating-point type.
     pub fn decode(&self) -> Vec<F> {
         alp_rd_decode(
             &self.left_parts,
@@ -175,16 +213,25 @@ where
 }
 
 impl RDEncoder {
-    /// Build a new encoder from a sample of doubles.
+    /// Builds a new encoder from a sample of doubles.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `sample` is empty.
     pub fn new<T>(sample: &[T]) -> Self
     where
         T: ALPRDFloat,
     {
+        assert!(
+            !sample.is_empty(),
+            "ALP-RD requires a non-empty sample to build a dictionary"
+        );
+
         let dictionary = find_best_dictionary::<T>(sample);
 
         let mut codes = vec![0; dictionary.dictionary.len()];
         dictionary.dictionary.into_iter().for_each(|(bits, code)| {
-            // write the reverse mapping into the codes vector.
+            // Write the reverse mapping into the codes vector.
             codes[code as usize] = bits
         });
 
@@ -194,8 +241,61 @@ impl RDEncoder {
         }
     }
 
-    /// Encode the floating point values into a result type.
+    /// Builds a new encoder from known parameters.
+    #[inline]
+    pub fn from_parts(right_bit_width: u8, codes: Vec<u16>) -> Self {
+        Self {
+            right_bit_width,
+            codes,
+        }
+    }
+
+    /// Returns the bit-width of the right (least significant) part of each value.
+    #[inline]
+    pub fn right_bit_width(&self) -> u8 {
+        self.right_bit_width
+    }
+
+    /// Returns the bit-width of the dictionary codes of the left (most significant) parts.
+    #[inline]
+    pub fn left_bit_width(&self) -> u8 {
+        bit_width(self.codes.len().saturating_sub(1) as u64)
+    }
+
+    /// Returns the dictionary of left parts, indexed by code.
+    #[inline]
+    pub fn codes(&self) -> &[u16] {
+        &self.codes
+    }
+
+    /// Encodes the floating-point values into a [`Split`].
     pub fn split<T>(&self, doubles: &[T]) -> Split<T, T::UINT>
+    where
+        T: ALPRDFloat,
+    {
+        let (left_parts, right_parts, exception_pos, exception_values) = self.split_parts(doubles);
+
+        // TODO(aduffy): pack the exception positions.
+        let left_exceptions = Exceptions::new(exception_values, exception_pos);
+
+        Split {
+            left_parts,
+            left_dict: self.codes.clone(),
+            left_exceptions,
+            left_parts_bit_width: self.left_bit_width(),
+            right_parts,
+            right_parts_bit_width: self.right_bit_width,
+            phantom_data: PhantomData,
+        }
+    }
+
+    /// Splits the floating-point values into their dictionary-encoded left parts, their right
+    /// parts, and the positions and values of the left parts that are not in the dictionary.
+    ///
+    /// The left parts are returned as dictionary codes, packable into
+    /// [`Self::left_bit_width`] bits; the right parts are packable into
+    /// [`Self::right_bit_width`] bits. Positions of exceptions hold a code of zero.
+    pub fn split_parts<T>(&self, doubles: &[T]) -> (Vec<u16>, Vec<T::UINT>, Vec<u64>, Vec<u16>)
     where
         T: ALPRDFloat,
     {
@@ -209,9 +309,8 @@ impl RDEncoder {
         let mut exception_pos: Vec<u64> = Vec::with_capacity(doubles.len() / 4);
         let mut exception_values: Vec<u16> = Vec::with_capacity(doubles.len() / 4);
 
-        // mask for right-parts
+        // Mask for the right parts.
         let right_mask = T::UINT::one().shl(self.right_bit_width as _) - T::UINT::one();
-        // let max_code = self.codes.len() - 1;
 
         for v in doubles.iter().copied() {
             right_parts.push(T::to_bits(v) & right_mask);
@@ -220,7 +319,7 @@ impl RDEncoder {
             ));
         }
 
-        // dict-encode the left-parts, keeping track of exceptions
+        // Dict-encode the left parts, keeping track of exceptions.
         for (idx, left) in left_parts.iter_mut().enumerate() {
             // TODO: revisit if we need to change the branch order for perf.
             if let Some(code) = self.codes.iter().position(|v| *v == *left) {
@@ -233,32 +332,16 @@ impl RDEncoder {
             }
         }
 
-        // Bit-pack the dict-encoded left_parts
-        // let left_parts = fastlanes_pack(&left_parts, left_bit_width);
-        // // Bit-pack the right_parts
-        // let right_parts = fastlanes_pack(&right_parts, self.right_bit_width as _);
-
-        // TODO(aduffy): pack the exception_pos.
-        let left_exceptions = Exceptions::new(exception_values, exception_pos);
-
-        Split {
-            left_parts,
-            left_dict: self.codes.clone(),
-            left_exceptions,
-            right_parts,
-            right_parts_bit_width: self.right_bit_width,
-            phantom_data: PhantomData,
-        }
+        (left_parts, right_parts, exception_pos, exception_values)
     }
 }
 
-/// Decode a vector of ALP-RD encoded values back into their original floating point format.
+/// Decodes a vector of ALP-RD encoded values back into their original floating-point format.
 ///
 /// # Panics
 ///
-/// The function panics if the provided `left_parts` and `right_parts` differ in length.
-///
-/// The function panics if the provided `exc_pos` and `exceptions` differ in length.
+/// Panics if `left_parts` and `right_parts` differ in length, or if `exc_pos` and `exceptions`
+/// differ in length.
 pub fn alp_rd_decode<T: ALPRDFloat>(
     left_parts: &[u16],
     left_parts_dict: &[u16],
@@ -279,36 +362,151 @@ pub fn alp_rd_decode<T: ALPRDFloat>(
         "alp_rd_decode: exc_pos.len != exceptions.len"
     );
 
-    let mut dict = Vec::with_capacity(left_parts_dict.len());
-    dict.extend_from_slice(left_parts_dict);
+    let mut decoded: Vec<T::UINT> = right_parts.to_vec();
 
-    let mut left_parts_decoded: Vec<T::UINT> = Vec::with_capacity(left_parts.len());
-
-    // Decode with bit-packing and dict unpacking.
-    for code in left_parts {
-        left_parts_decoded.push(<T as ALPRDFloat>::from_u16(dict[*code as usize]));
+    if exc_pos.is_empty() {
+        // Non-patched fast path: every code maps through the dictionary, so we can
+        // pre-shift the entire dictionary once and reduce the per-element hot loop to
+        // a single table lookup + OR.
+        alp_rd_combine_codes_inplace::<T>(
+            &mut decoded,
+            left_parts,
+            left_parts_dict,
+            right_bit_width,
+        );
+    } else {
+        // Patched path: some left-part codes map to exception values that live outside
+        // the dictionary. We must dictionary-decode first, then overwrite the exceptions,
+        // before we can combine with right-parts.
+        let mut left_parts = left_parts.to_vec();
+        alp_rd_dict_decode_inplace(&mut left_parts, left_parts_dict);
+        alp_rd_apply_patches(&mut left_parts, exc_pos, exceptions, 0);
+        alp_rd_combine_inplace::<T>(&mut decoded, &left_parts, right_bit_width);
     }
 
-    // Apply the exception patches to left_parts
-    for (pos, val) in exc_pos.iter().zip(exceptions.iter()) {
-        left_parts_decoded[*pos as usize] = <T as ALPRDFloat>::from_u16(*val);
-    }
-
-    // recombine the left-and-right parts, adjusting by the right_bit_width.
-    left_parts_decoded
-        .into_iter()
-        .zip(right_parts.iter().copied())
-        .map(|(left, right)| T::from_bits((left << (right_bit_width as usize)) | right))
-        .collect()
+    decoded.into_iter().map(T::from_bits).collect()
 }
 
-/// Find the best "cut point" for a set of floating point values such that we can
-/// cast them all to the relevant value instead.
+/// Replaces each dictionary code in `left_parts` with the left bit-pattern it encodes.
+///
+/// # Panics
+///
+/// Panics if `left_parts` contains a code that is not in `left_parts_dict`.
+#[inline]
+pub fn alp_rd_dict_decode_inplace(left_parts: &mut [u16], left_parts_dict: &[u16]) {
+    for code in left_parts.iter_mut() {
+        *code = left_parts_dict[*code as usize];
+    }
+}
+
+/// Overwrites the exception positions of already dictionary-decoded `left_parts` with their true
+/// left bit-patterns.
+///
+/// `offset` is subtracted from every index, to support patches that are stored relative to the
+/// start of an unsliced array.
+///
+/// # Panics
+///
+/// Panics if `indices` and `patch_values` differ in length, or if an index is out of bounds.
+#[inline]
+pub fn alp_rd_apply_patches<I: PrimInt>(
+    left_parts: &mut [u16],
+    indices: &[I],
+    patch_values: &[u16],
+    offset: usize,
+) {
+    assert_eq!(
+        indices.len(),
+        patch_values.len(),
+        "alp_rd_apply_patches: indices.len != patch_values.len"
+    );
+
+    indices
+        .iter()
+        .copied()
+        .zip(patch_values.iter().copied())
+        .for_each(|(idx, value)| {
+            let idx = idx
+                .to_usize()
+                .expect("alp_rd_apply_patches: index out of range")
+                - offset;
+            left_parts[idx] = value;
+        });
+}
+
+/// Combines dictionary-decoded `left_parts` into `right_parts` in-place, so that each element of
+/// `right_parts` holds the bit-pattern of the original float.
+///
+/// # Panics
+///
+/// Panics if `left_parts` and `right_parts` differ in length.
+#[inline]
+pub fn alp_rd_combine_inplace<T: ALPRDFloat>(
+    right_parts: &mut [T::UINT],
+    left_parts: &[u16],
+    right_bit_width: u8,
+) {
+    assert_eq!(
+        left_parts.len(),
+        right_parts.len(),
+        "alp_rd_combine_inplace: left_parts.len != right_parts.len"
+    );
+
+    let shift = right_bit_width as usize;
+    for (right, left) in right_parts.iter_mut().zip(left_parts.iter().copied()) {
+        *right = (<T as ALPRDFloat>::from_u16(left) << shift) | *right;
+    }
+}
+
+/// Combines dictionary-encoded left parts into `right_parts` in-place, so that each element of
+/// `right_parts` holds the bit-pattern of the original float.
+///
+/// This is the unpatched fast path: the dictionary is pre-shifted once, reducing the hot loop to
+/// a table lookup and an OR. Codes are masked into the dictionary, so codes beyond the dictionary
+/// size decode to garbage rather than panicking.
+///
+/// # Panics
+///
+/// Panics if `left_parts` and `right_parts` differ in length, or if the dictionary holds more
+/// than [`MAX_DICT_SIZE`] entries.
+#[inline]
+pub fn alp_rd_combine_codes_inplace<T: ALPRDFloat>(
+    right_parts: &mut [T::UINT],
+    left_parts: &[u16],
+    left_parts_dict: &[u16],
+    right_bit_width: u8,
+) {
+    assert_eq!(
+        left_parts.len(),
+        right_parts.len(),
+        "alp_rd_combine_codes_inplace: left_parts.len != right_parts.len"
+    );
+    assert!(
+        left_parts_dict.len() <= MAX_DICT_SIZE as usize,
+        "alp_rd_combine_codes_inplace: dictionary larger than MAX_DICT_SIZE"
+    );
+
+    let shift = right_bit_width as usize;
+    let mut shifted_dict = [T::UINT::zero(); MAX_DICT_SIZE as usize];
+    for (i, &entry) in left_parts_dict.iter().enumerate() {
+        shifted_dict[i] = <T as ALPRDFloat>::from_u16(entry) << shift;
+    }
+
+    // Masking keeps the lookup in-bounds without a branch; codes are < dictionary size by
+    // construction.
+    const CODE_MASK: usize = MAX_DICT_SIZE as usize - 1;
+    for (right, code) in right_parts.iter_mut().zip(left_parts.iter().copied()) {
+        *right = shifted_dict[(code as usize) & CODE_MASK] | *right;
+    }
+}
+
+/// Finds the best "cut point" for a set of floating-point values, i.e. the one with the lowest
+/// estimated compressed size.
 fn find_best_dictionary<T: ALPRDFloat>(samples: &[T]) -> ALPRDDictionary {
     let mut best_est_size = f64::MAX;
     let mut best_dict = ALPRDDictionary::default();
 
-    for p in 1..=16 {
+    for p in 1..=CUT_LIMIT {
         let candidate_right_bw = (T::BITS - p) as u8;
         let (dictionary, exception_count) =
             build_left_parts_dictionary::<T>(samples, candidate_right_bw, MAX_DICT_SIZE);
@@ -327,7 +525,7 @@ fn find_best_dictionary<T: ALPRDFloat>(samples: &[T]) -> ALPRDDictionary {
     best_dict
 }
 
-/// Build dictionary of the leftmost bits.
+/// Builds a dictionary of the leftmost bits.
 fn build_left_parts_dictionary<T: ALPRDFloat>(
     samples: &[T],
     right_bw: u8,
@@ -338,8 +536,8 @@ fn build_left_parts_dictionary<T: ALPRDFloat>(
         "left-parts must be <= 16 bits"
     );
 
-    // Count the number of occurrences of each left bit pattern
-    let mut counts = HashMap::new();
+    // Count the number of occurrences of each left bit pattern.
+    let mut counts = FxHashMap::default();
     samples
         .iter()
         .copied()
@@ -351,7 +549,8 @@ fn build_left_parts_dictionary<T: ALPRDFloat>(
     sorted_bit_counts.sort_by_key(|(_, count)| count.wrapping_neg());
 
     // Assign the most-frequently occurring left-bits as dictionary codes, up to `dict_size`...
-    let mut dictionary = HashMap::with_capacity(max_dict_size as _);
+    let mut dictionary =
+        FxHashMap::with_capacity_and_hasher(max_dict_size as _, Default::default());
     let mut code = 0u16;
     while code < (max_dict_size as _) && (code as usize) < sorted_bit_counts.len() {
         let (bits, _) = sorted_bit_counts[code as usize];
@@ -368,7 +567,7 @@ fn build_left_parts_dictionary<T: ALPRDFloat>(
 
     // Left bit-width is determined based on the actual dictionary size.
     let max_code = dictionary.len() - 1;
-    let left_bw = bit_width!(max_code) as u8;
+    let left_bw = bit_width(max_code as u64);
 
     (
         ALPRDDictionary {
@@ -380,7 +579,7 @@ fn build_left_parts_dictionary<T: ALPRDFloat>(
     )
 }
 
-/// Estimate the bits-per-value when using these compression settings.
+/// Estimates the bits-per-value when using these compression settings.
 fn estimate_compression_size(
     right_bw: u8,
     left_bw: u8,
@@ -398,16 +597,19 @@ fn estimate_compression_size(
 #[derive(Debug, Default)]
 struct ALPRDDictionary {
     /// Items in the dictionary are bit patterns, along with their 16-bit encoding.
-    dictionary: HashMap<u16, u16>,
-    /// The (compressed) left bit width. This is after bit-packing the dictionary codes.
+    dictionary: FxHashMap<u16, u16>,
+    /// The (compressed) left bit-width. This is after bit-packing the dictionary codes.
     left_bit_width: u8,
-    /// The right bit width. This is the bit-packed width of each of the "real double" values.
+    /// The right bit-width. This is the bit-packed width of each of the "real double" values.
     right_bit_width: u8,
 }
 
 #[cfg(test)]
 mod test {
-    use crate::RDEncoder;
+    use crate::{
+        alp_rd_apply_patches, alp_rd_combine_codes_inplace, alp_rd_combine_inplace, alp_rd_decode,
+        alp_rd_dict_decode_inplace, bit_width, RDEncoder, MAX_DICT_SIZE,
+    };
 
     #[test]
     fn test_encode_decode() {
@@ -418,5 +620,130 @@ mod test {
         let split = encoder.split(&values);
         let decoded = split.decode();
         assert_eq!(decoded, values);
+    }
+
+    #[test]
+    fn test_encode_decode_with_exceptions() {
+        // The outlier has a different exponent, so its left parts are not in the dictionary.
+        let values = vec![0.1f64, 0.2f64, 3e100f64];
+        let encoder = RDEncoder::new(&values[0..2]);
+
+        let split = encoder.split(&values);
+        assert_eq!(split.left_exceptions().positions(), &[2]);
+        assert_eq!(split.decode(), values);
+    }
+
+    #[test]
+    fn test_encode_decode_f32() {
+        let values = vec![0.1f32, 0.2f32, 3e25f32];
+        let encoder = RDEncoder::new(&values[0..2]);
+
+        let split = encoder.split(&values);
+        assert_eq!(split.left_exceptions().positions(), &[2]);
+        assert_eq!(split.decode(), values);
+    }
+
+    #[test]
+    fn test_from_parts_round_trips() {
+        let values = vec![1.12345f64, 2.34567f64, 3.45678f64];
+        let encoder = RDEncoder::new(&values);
+
+        let rebuilt = RDEncoder::from_parts(encoder.right_bit_width(), encoder.codes().to_vec());
+        assert_eq!(rebuilt.right_bit_width(), encoder.right_bit_width());
+        assert_eq!(rebuilt.codes(), encoder.codes());
+        assert_eq!(rebuilt.split(&values).decode(), values);
+    }
+
+    #[test]
+    fn test_bit_widths() {
+        let values = vec![1.12345f64, 2.34567f64, 3.45678f64];
+        let encoder = RDEncoder::new(&values);
+        let split = encoder.split(&values);
+
+        assert!(encoder.codes().len() <= MAX_DICT_SIZE as usize);
+        assert_eq!(split.left_parts_bit_width(), encoder.left_bit_width());
+        assert_eq!(
+            split.left_parts_bit_width() as usize,
+            bit_width((encoder.codes().len() - 1) as u64) as usize
+        );
+        assert_eq!(split.right_parts_bit_width(), encoder.right_bit_width());
+        assert!(split
+            .right_parts()
+            .iter()
+            .all(|v| *v < (1u64 << split.right_parts_bit_width())));
+    }
+
+    #[test]
+    fn test_decode_primitives_match() {
+        let values = vec![0.1f64, 0.2f64, 3e100f64];
+        let encoder = RDEncoder::new(&values[0..2]);
+        let (left_parts, right_parts, exc_pos, exc_values) = encoder.split_parts(&values);
+        let dict = encoder.codes();
+        let right_bit_width = encoder.right_bit_width();
+
+        // Piecewise decode, as a consumer holding its own buffers would do it.
+        let mut left = left_parts.clone();
+        alp_rd_dict_decode_inplace(&mut left, dict);
+        alp_rd_apply_patches(&mut left, &exc_pos, &exc_values, 0);
+        let mut combined = right_parts.clone();
+        alp_rd_combine_inplace::<f64>(&mut combined, &left, right_bit_width);
+        let decoded: Vec<f64> = combined.into_iter().map(f64::from_bits).collect();
+
+        assert_eq!(
+            decoded,
+            alp_rd_decode::<f64>(
+                &left_parts,
+                dict,
+                right_bit_width,
+                &right_parts,
+                &exc_pos,
+                &exc_values
+            )
+        );
+        assert_eq!(decoded, values);
+    }
+
+    #[test]
+    fn test_combine_codes_matches_combine() {
+        let values = vec![1.12345f64, 2.34567f64, 3.45678f64];
+        let encoder = RDEncoder::new(&values);
+        let (left_parts, right_parts, exc_pos, _) = encoder.split_parts(&values);
+        assert!(exc_pos.is_empty());
+
+        let mut fast = right_parts.clone();
+        alp_rd_combine_codes_inplace::<f64>(
+            &mut fast,
+            &left_parts,
+            encoder.codes(),
+            encoder.right_bit_width(),
+        );
+
+        let mut left = left_parts.clone();
+        alp_rd_dict_decode_inplace(&mut left, encoder.codes());
+        let mut slow = right_parts;
+        alp_rd_combine_inplace::<f64>(&mut slow, &left, encoder.right_bit_width());
+
+        assert_eq!(fast, slow);
+        assert_eq!(
+            fast.into_iter().map(f64::from_bits).collect::<Vec<_>>(),
+            values
+        );
+    }
+
+    #[test]
+    fn test_apply_patches_with_offset() {
+        // Patch indices are relative to the start of the unsliced array.
+        let mut left = vec![0u16; 3];
+        alp_rd_apply_patches(&mut left, &[10u64, 12], &[7u16, 9], 10);
+        assert_eq!(left, vec![7, 0, 9]);
+    }
+
+    #[test]
+    fn test_bit_width_fn() {
+        assert_eq!(bit_width(0), 1);
+        assert_eq!(bit_width(1), 1);
+        assert_eq!(bit_width(2), 2);
+        assert_eq!(bit_width(7), 3);
+        assert_eq!(bit_width(u64::MAX), 64);
     }
 }

--- a/src/alp_rd/mod.rs
+++ b/src/alp_rd/mod.rs
@@ -57,22 +57,22 @@ pub trait ALPRDFloat: private::Sealed + Float {
 impl ALPRDFloat for f64 {
     type UINT = u64;
 
-    #[inline(always)]
+    #[inline]
     fn from_bits(bits: Self::UINT) -> Self {
         f64::from_bits(bits)
     }
 
-    #[inline(always)]
+    #[inline]
     fn to_bits(value: Self) -> Self::UINT {
         value.to_bits()
     }
 
-    #[inline(always)]
+    #[inline]
     fn to_u16(bits: Self::UINT) -> u16 {
         bits as u16
     }
 
-    #[inline(always)]
+    #[inline]
     fn from_u16(value: u16) -> Self::UINT {
         value as u64
     }
@@ -81,22 +81,22 @@ impl ALPRDFloat for f64 {
 impl ALPRDFloat for f32 {
     type UINT = u32;
 
-    #[inline(always)]
+    #[inline]
     fn from_bits(bits: Self::UINT) -> Self {
         f32::from_bits(bits)
     }
 
-    #[inline(always)]
+    #[inline]
     fn to_bits(value: Self) -> Self::UINT {
         value.to_bits()
     }
 
-    #[inline(always)]
+    #[inline]
     fn to_u16(bits: Self::UINT) -> u16 {
         bits as u16
     }
 
-    #[inline(always)]
+    #[inline]
     fn from_u16(value: u16) -> Self::UINT {
         value as u32
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,73 @@
-//! This crate contains an implementation of the floating point compression algorithm from the
+//! This crate contains an implementation of the floating-point compression algorithm from the
 //! paper ["ALP: Adaptive Lossless floating-Point Compression"][paper] by Afroozeh et al.
 //!
-//! The compressor has two variants, classic ALP which is well-suited for data that does not use
-//! the full precision, and "real doubles", values that do.
+//! The compressor has two variants: classic ALP, which is well-suited for data that does not use
+//! the full precision, and "real doubles", for values that do.
 //!
 //! Classic ALP will return small integers, and it is meant to be cascaded with other integer
-//! compression techniques such as bit-packing and frame-of-reference encoding. Combined this allows
-//! for significant compression on the order of what you can get for integer values.
+//! compression techniques such as bit-packing and frame-of-reference encoding. Combined, this
+//! allows for significant compression on the order of what you can get for integer values.
 //!
-//! ALP-RD is generally terminal, and in the ideal case it can represent an f64 is just 49 bits,
+//! ALP-RD is generally terminal, and in the ideal case it can represent an f64 in just 49 bits,
 //! though generally it is closer to 54 bits per value or ~12.5% compression.
+//!
+//! # Classic ALP
+//!
+//! [`encode`] picks the best exponents for the input (unless they are given), and returns the
+//! encoded integers alongside the positions and values of the exceptions that do not round-trip.
+//! Exceptional slots in the encoded output hold a fill value, so that they stay in range for
+//! downstream integer compression. Values are encoded in chunks of [`ENCODE_CHUNK_SIZE`], and one
+//! offset per chunk is returned, so a consumer can find the exceptions of a chunk without scanning
+//! the whole patch index.
+//!
+//! ```
+//! let values = vec![1.234f64, 5.678, 9.0];
+//! let (exponents, encoded, patch_indices, patch_values, chunk_offsets) =
+//!     alp::encode(&values, None);
+//!
+//! assert_eq!(encoded, vec![1234, 5678, 9000]);
+//! assert!(patch_indices.is_empty() && patch_values.is_empty());
+//! assert_eq!(chunk_offsets, vec![0]);
+//! assert_eq!(alp::decode::<f64>(&encoded, exponents), values);
+//! ```
+//!
+//! Decoding is usually done in place, over the encoded buffer itself
+//! ([`decode_slice_inplace`]). If you plan to do that, encode with [`encode_into`] so the values
+//! land in a buffer you own from the start, rather than in a `Vec` you would have to adopt:
+//!
+//! ```
+//! # let values = vec![1.234f64, 5.678, 9.0];
+//! let mut encoded: Vec<i64> = Vec::with_capacity(values.len());
+//! let (mut patch_indices, mut patch_values, mut chunk_offsets) = (vec![], vec![], vec![]);
+//!
+//! let exponents = alp::encode_into(
+//!     &values,
+//!     None,
+//!     &mut encoded.spare_capacity_mut()[..values.len()],
+//!     &mut patch_indices,
+//!     &mut patch_values,
+//!     &mut chunk_offsets,
+//! );
+//! // SAFETY: `encode_into` initializes one element per value.
+//! unsafe { encoded.set_len(values.len()) };
+//!
+//! alp::decode_slice_inplace::<f64>(&mut encoded, exponents);
+//! ```
+//!
+//! # ALP-RD
+//!
+//! [`RDEncoder`] derives a dictionary of the most common front bits from a sample, and then splits
+//! values into dictionary-encoded left parts and bit-packable right parts. Left parts that are not
+//! in the dictionary are stored as exceptions.
+//!
+//! ```
+//! let values = vec![0.1f64, 0.2, 3e100];
+//! let encoder = alp::RDEncoder::new(&values[0..2]);
+//!
+//! let split = encoder.split(&values);
+//! assert_eq!(split.left_exceptions().positions(), &[2]);
+//! assert_eq!(split.decode(), values);
+//! ```
 //!
 //! [paper]: https://ir.cwi.nl/pub/33334/33334.pdf
 
@@ -22,7 +80,7 @@ mod alp_rd;
 /// A sparse vector containing exceptions to the encoding process.
 ///
 /// When either of the ALP variants encounters values it is unable to compress, they are stored
-/// in here using the actual encoding offsets instead.
+/// here using the actual encoding offsets instead.
 ///
 /// Indices should be stored bit-packed, so that they can be accessed that way.
 pub struct Exceptions<T> {
@@ -34,11 +92,51 @@ impl<T> Exceptions<T>
 where
     T: Copy,
 {
+    /// Creates a set of exceptions from the values and the positions they belong at.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `values` and `positions` have different lengths.
     pub fn new(values: Vec<T>, positions: Vec<u64>) -> Self {
+        assert_eq!(
+            values.len(),
+            positions.len(),
+            "Exceptions: values.len != positions.len"
+        );
         Self { values, positions }
     }
 
-    /// Apply the exceptions to the given array.
+    /// Returns the exceptional values.
+    #[inline]
+    pub fn values(&self) -> &[T] {
+        &self.values
+    }
+
+    /// Returns the positions of the exceptional values.
+    #[inline]
+    pub fn positions(&self) -> &[u64] {
+        &self.positions
+    }
+
+    /// Returns the number of exceptions.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.positions.len()
+    }
+
+    /// Returns `true` if there are no exceptions.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.positions.is_empty()
+    }
+
+    /// Consumes the exceptions, returning the values and their positions.
+    pub fn into_parts(self) -> (Vec<T>, Vec<u64>) {
+        (self.values, self.positions)
+    }
+
+    /// Applies the exceptions to the given array.
+    #[inline]
     pub fn apply(&self, vec: &mut [T]) {
         self.values
             .iter()
@@ -53,11 +151,14 @@ mod test {
 
     #[test]
     fn test_apply_exceptions() {
-        let exceptions = Exceptions::new(vec![0u8; 4], vec![1, 2, 3]);
+        let exceptions = Exceptions::new(vec![0u8; 3], vec![1, 2, 3]);
 
         let mut values = vec![10; 4];
         exceptions.apply(&mut values);
 
         assert_eq!(values, vec![10, 0, 0, 0]);
+        assert_eq!(exceptions.len(), 3);
+        assert_eq!(exceptions.positions(), &[1, 2, 3]);
+        assert_eq!(exceptions.values(), &[0, 0, 0]);
     }
 }


### PR DESCRIPTION
Along the feature additions we also add apis that take the output buffer as an
input instead of creating their own

