### PR TITLE
Sample contiguous runs in the ALP exponent search

### DIFF
--- a/src/alp/mod.rs
+++ b/src/alp/mod.rs
@@ -1,9 +1,22 @@
+use crate::sample::SamplePlan;
 use itertools::Itertools;
 use num_traits::{CheckedSub, Float, PrimInt, ToPrimitive};
 use std::fmt::{Display, Formatter};
 use std::mem::{MaybeUninit, size_of, transmute, transmute_copy};
 
-const SAMPLE_SIZE: usize = 32;
+/// Number of values [`ALPFloat::find_best_exponents`] examines.
+///
+/// Every candidate exponent pair is tried on every sampled value, so this bounds the cost of the
+/// search: it is the same for a million values as for a few dozen. Eight runs of [`SAMPLE_BLOCK`]
+/// values, as DuckDB's ALP samples eight vectors of a row group.
+const SAMPLE_SIZE: usize = 64;
+
+/// Length of each contiguous run of values [`ALPFloat::find_best_exponents`] samples.
+///
+/// Runs, rather than a fixed stride, keep the sample from aliasing with periodic input; see
+/// [`SamplePlan::subsample`]. Values that share a row tend to share a precision, so a short run
+/// costs little breadth, and eight of them spread over the input see eight regions of the column.
+const SAMPLE_BLOCK: usize = 8;
 
 /// The number of values encoded per chunk.
 ///
@@ -170,26 +183,24 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
 
     /// Finds the exponent pair with the smallest estimated encoded size.
     ///
-    /// Inputs longer than a few dozen values are sampled rather than scanned in full, since the
-    /// number of decimal digits a column uses is a property of the column rather than of any one
-    /// value.
+    /// Inputs longer than a few dozen values are sampled rather than scanned in full, as evenly
+    /// spread contiguous runs of values, since the number of decimal digits a column uses is a
+    /// property of the column rather than of any one value.
     fn find_best_exponents(values: &[Self]) -> Exponents {
-        let mut best_exp = Exponents { e: 0, f: 0 };
+        let plan = SamplePlan::subsample(values.len(), SAMPLE_SIZE, SAMPLE_BLOCK);
+        let sample: Vec<Self> = plan.iter(values).copied().collect();
 
-        let sample = (values.len() > SAMPLE_SIZE).then(|| {
-            values
-                .iter()
-                .step_by(values.len() / SAMPLE_SIZE)
-                .cloned()
-                .collect_vec()
-        });
-        let sample = sample.as_deref().unwrap_or(values);
-        let mut best_nbytes = Self::estimate_encoded_size_for_exponents(sample, best_exp);
+        let mut best_exp = Exponents { e: 0, f: 0 };
+        let mut best_nbytes = Self::estimate_encoded_size_for_exponents(&sample, best_exp);
 
         for e in (0..Self::MAX_EXPONENT).rev() {
             for f in 0..=e {
                 let exp = Exponents { e, f };
-                let size = Self::estimate_encoded_size_for_exponents(sample, exp);
+                // A candidate whose exceptions alone already cost more than the best so far cannot
+                // win, or tie, so the estimate gives up on it part-way through the sample.
+                let Some(size) = estimate_encoded_size_within(&sample, exp, best_nbytes) else {
+                    continue;
+                };
                 if size < best_nbytes {
                     best_nbytes = size;
                     best_exp = exp;
@@ -206,47 +217,8 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
     /// [`Self::encode`] plus [`Self::estimate_encoded_size`] but without the per-candidate
     /// allocations.
     fn estimate_encoded_size_for_exponents(values: &[Self], exponents: Exponents) -> usize {
-        // `kept` is the (min, max) over values that round-trip exactly (kept inline by `encode`);
-        // `all` is the (min, max) over every encoded value. `encode` fills patched slots in-range,
-        // so its emitted range is `kept`, except with all values patched (no fill), where `all`
-        // wins.
-        let mut kept: Option<(Self::ALPInt, Self::ALPInt)> = None;
-        let mut all: Option<(Self::ALPInt, Self::ALPInt)> = None;
-        let mut patch_count = 0usize;
-
-        for &value in values {
-            let encoded = Self::encode_single_unchecked(value, exponents);
-            update_bounds(&mut all, encoded);
-            if Self::decode_single(encoded, exponents).is_eq(value) {
-                update_bounds(&mut kept, encoded);
-            } else {
-                patch_count += 1;
-            }
-        }
-
-        let range = if patch_count == values.len() {
-            all
-        } else {
-            kept
-        };
-
-        let bits_per_encoded = range
-            .and_then(|(min, max)| max.checked_sub(&min))
-            .and_then(|range_size| range_size.to_u64())
-            .and_then(|range_size| {
-                range_size
-                    .checked_ilog2()
-                    .map(|bits| (bits + 1) as usize)
-                    .or(Some(0))
-            })
-            .unwrap_or(size_of::<Self::ALPInt>() * 8);
-
-        let encoded_bytes = (values.len() * bits_per_encoded).div_ceil(8);
-        // Each patch is a value plus a position. In practice, patch positions are in
-        // [0, u16::MAX] because of how we chunk.
-        let patch_bytes = patch_count * (size_of::<Self>() + size_of::<u16>());
-
-        encoded_bytes + patch_bytes
+        estimate_encoded_size_within(values, exponents, usize::MAX)
+            .expect("an unbounded estimate always completes")
     }
 
     /// Estimates the bytes `encoded` and `patches` occupy once cascaded, assuming the encoded
@@ -270,11 +242,7 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
             .unwrap_or(size_of::<Self::ALPInt>() * 8);
 
         let encoded_bytes = (encoded.len() * bits_per_encoded).div_ceil(8);
-        // Each patch is a value plus a position. In practice, patch positions are in
-        // [0, u16::MAX] because of how we chunk.
-        let patch_bytes = patches.len() * (size_of::<Self>() + size_of::<u16>());
-
-        encoded_bytes + patch_bytes
+        encoded_bytes + patches.len() * patch_bytes::<Self>()
     }
 
     /// Encodes `values`, finding the best exponents if they are not provided.
@@ -453,6 +421,68 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
             .fast_round()
             .as_int()
     }
+}
+
+/// Bytes one exception costs: its value at full precision, plus a position.
+///
+/// In practice, patch positions are in `[0, u16::MAX]` because of how we chunk.
+const fn patch_bytes<T>() -> usize {
+    size_of::<T>() + size_of::<u16>()
+}
+
+/// [`ALPFloat::estimate_encoded_size_for_exponents`], giving up as soon as the exceptions alone
+/// cost more than `limit` bytes.
+///
+/// Returns `None` for a candidate that cannot come in at or under `limit`, so a search can pass
+/// its best size so far and skip the rest of the sample for every pair that has already lost.
+/// The bound is exact: every exception adds [`patch_bytes`] to the final estimate, so a running
+/// exception cost above `limit` puts the total above it too, and a candidate that is not
+/// abandoned is scored exactly as the unbounded estimate would.
+fn estimate_encoded_size_within<T: ALPFloat>(
+    values: &[T],
+    exponents: Exponents,
+    limit: usize,
+) -> Option<usize> {
+    // `kept` is the (min, max) over values that round-trip exactly (kept inline by `encode`);
+    // `all` is the (min, max) over every encoded value. `encode` fills patched slots in-range,
+    // so its emitted range is `kept`, except with all values patched (no fill), where `all`
+    // wins.
+    let mut kept: Option<(T::ALPInt, T::ALPInt)> = None;
+    let mut all: Option<(T::ALPInt, T::ALPInt)> = None;
+    let mut patch_count = 0usize;
+
+    for &value in values {
+        let encoded = T::encode_single_unchecked(value, exponents);
+        update_bounds(&mut all, encoded);
+        if T::decode_single(encoded, exponents).is_eq(value) {
+            update_bounds(&mut kept, encoded);
+        } else {
+            patch_count += 1;
+            if patch_count * patch_bytes::<T>() > limit {
+                return None;
+            }
+        }
+    }
+
+    let range = if patch_count == values.len() {
+        all
+    } else {
+        kept
+    };
+
+    let bits_per_encoded = range
+        .and_then(|(min, max)| max.checked_sub(&min))
+        .and_then(|range_size| range_size.to_u64())
+        .and_then(|range_size| {
+            range_size
+                .checked_ilog2()
+                .map(|bits| (bits + 1) as usize)
+                .or(Some(0))
+        })
+        .unwrap_or(size_of::<T::ALPInt>() * 8);
+
+    let encoded_bytes = (values.len() * bits_per_encoded).div_ceil(8);
+    Some(encoded_bytes + patch_count * patch_bytes::<T>())
 }
 
 /// Encodes one chunk into `encoded_output`, which covers the whole array: elements before
@@ -709,6 +739,160 @@ mod tests {
         f32s.extend([1e9, -1e9, 0.0, 123.0]);
         check_estimate_matches(&f32s);
         check_estimate_matches::<f32>(&[1.0 / 3.0; 8]);
+    }
+
+    /// A small linear congruential generator, so the tests need no extra dependencies.
+    struct Lcg(u64);
+
+    impl Lcg {
+        fn new() -> Self {
+            Self(0x517C_C1B7_2722_0A95)
+        }
+
+        /// A value in `[0, 1)`.
+        fn next_unit(&mut self) -> f64 {
+            self.0 = self
+                .0
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            (self.0 >> 11) as f64 / (1u64 << 53) as f64
+        }
+
+        /// A value with `digits` decimal places, below `magnitude`.
+        fn next_decimal(&mut self, magnitude: f64, digits: i32) -> f64 {
+            let scale = 10f64.powi(digits);
+            (self.next_unit() * magnitude * scale).round() / scale
+        }
+    }
+
+    /// The search, without the bound that lets it abandon losing candidates early.
+    fn reference_search<T: ALPFloat>(sample: &[T]) -> Exponents {
+        let mut best_exp = Exponents { e: 0, f: 0 };
+        let mut best_nbytes = T::estimate_encoded_size_for_exponents(sample, best_exp);
+        for e in (0..T::MAX_EXPONENT).rev() {
+            for f in 0..=e {
+                let exp = Exponents { e, f };
+                let size = T::estimate_encoded_size_for_exponents(sample, exp);
+                if size < best_nbytes {
+                    best_nbytes = size;
+                    best_exp = exp;
+                } else if size == best_nbytes && e - f < best_exp.e - best_exp.f {
+                    best_exp = exp;
+                }
+            }
+        }
+        best_exp
+    }
+
+    // Abandoning candidates part-way must not change what the search picks: the bound is a proof
+    // that the candidate has lost, not a heuristic.
+    #[test]
+    fn bounded_search_matches_unbounded_search() {
+        let mut rng = Lcg::new();
+        let shapes: [Vec<f64>; 6] = [
+            (0..SAMPLE_SIZE)
+                .map(|_| rng.next_decimal(1000.0, 2))
+                .collect(),
+            (0..SAMPLE_SIZE).map(|_| rng.next_decimal(1.0, 6)).collect(),
+            (0..SAMPLE_SIZE).map(|_| rng.next_unit()).collect(),
+            (0..SAMPLE_SIZE)
+                .map(|i| rng.next_decimal(100.0, if i % 2 == 0 { 1 } else { 5 }))
+                .collect(),
+            vec![1.0 / 3.0; SAMPLE_SIZE],
+            vec![std::f64::consts::PI, 0.5, -0.0, f64::NAN, 1e17, 2.25],
+        ];
+        for sample in &shapes {
+            assert_eq!(find_best_exponents(sample), reference_search(sample));
+            let f32s: Vec<f32> = sample.iter().map(|&v| v as f32).collect();
+            assert_eq!(find_best_exponents(&f32s), reference_search(&f32s));
+        }
+    }
+
+    #[test]
+    fn bounded_estimate_matches_unbounded_estimate() {
+        let mut rng = Lcg::new();
+        let sample: Vec<f64> = (0..SAMPLE_SIZE)
+            .map(|i| rng.next_decimal(100.0, if i % 4 == 0 { 8 } else { 2 }))
+            .collect();
+        for e in 0..f64::MAX_EXPONENT {
+            for f in 0..=e {
+                let exp = Exponents { e, f };
+                let size = f64::estimate_encoded_size_for_exponents(&sample, exp);
+                assert_eq!(estimate_encoded_size_within(&sample, exp, size), Some(size));
+                assert_eq!(
+                    estimate_encoded_size_within(&sample, exp, usize::MAX),
+                    Some(size)
+                );
+                // Too tight a bound gives up exactly when the exceptions alone exceed it.
+                let patches = (size - {
+                    let (_, encoded, ..) = f64::encode(&sample, Some(exp));
+                    f64::estimate_encoded_size(&encoded, &[])
+                }) / patch_bytes::<f64>();
+                if patches > 0 {
+                    assert_eq!(
+                        estimate_encoded_size_within(
+                            &sample,
+                            exp,
+                            patches * patch_bytes::<f64>() - 1
+                        ),
+                        None
+                    );
+                }
+            }
+        }
+    }
+
+    // A stride of `len / SAMPLE_SIZE` lands on one phase of any input whose period divides it.
+    // Here every value at such a position is an integer while the rest have five decimals, so a
+    // strided sample would see only integers and pick no scaling at all, leaving the rest of the
+    // column as exceptions. Runs see the decimals.
+    #[test]
+    fn sampling_is_robust_to_periodic_input() {
+        let mut rng = Lcg::new();
+        for len in [SAMPLE_SIZE * 64, 65_536, 100_003] {
+            let period = len / SAMPLE_SIZE;
+            let values: Vec<f64> = (0..len)
+                .map(|i| {
+                    if i % period == 0 {
+                        rng.next_decimal(1000.0, 0)
+                    } else {
+                        rng.next_decimal(1000.0, 5)
+                    }
+                })
+                .collect();
+
+            let exponents = find_best_exponents(&values);
+            assert_eq!(exponents.e - exponents.f, 5, "len {len}: {exponents}");
+        }
+    }
+
+    // Sampling must not cost compression on data whose precision is uniform throughout, which is
+    // the case classic ALP is for.
+    #[test]
+    fn sampled_search_matches_full_scan_on_uniform_data() {
+        let mut rng = Lcg::new();
+        for digits in [0, 2, 6] {
+            let values: Vec<f64> = (0..20_000)
+                .map(|_| rng.next_decimal(1000.0, digits))
+                .collect();
+            let sampled = find_best_exponents(&values);
+            let full = reference_search(&values);
+            assert_eq!(
+                sampled.e - sampled.f,
+                full.e - full.f,
+                "{digits} digits: sampled {sampled}, full scan {full}"
+            );
+            // A few decimals do not survive the two multiplications at any pair, so compare
+            // exception counts rather than demanding none.
+            let (_, _, sampled_patches, ..) = encode(&values, Some(sampled));
+            let (_, _, full_patches, ..) = encode(&values, Some(full));
+            assert!(
+                sampled_patches.len() <= full_patches.len(),
+                "{digits} digits: {} exceptions sampled, {} with a full scan",
+                sampled_patches.len(),
+                full_patches.len()
+            );
+        }
     }
 
     #[test]

--- a/src/alp/mod.rs
+++ b/src/alp/mod.rs
@@ -4,18 +4,8 @@ use num_traits::{CheckedSub, Float, PrimInt, ToPrimitive};
 use std::fmt::{Display, Formatter};
 use std::mem::{MaybeUninit, size_of, transmute, transmute_copy};
 
-/// Number of values [`ALPFloat::find_best_exponents`] examines.
-///
-/// Every candidate exponent pair is tried on every sampled value, so this bounds the cost of the
-/// search: it is the same for a million values as for a few dozen. Eight runs of [`SAMPLE_BLOCK`]
-/// values, as DuckDB's ALP samples eight vectors of a row group.
+/// Maximum number of values examined per candidate exponent pair.
 const SAMPLE_SIZE: usize = 64;
-
-/// Length of each contiguous run of values [`ALPFloat::find_best_exponents`] samples.
-///
-/// Runs, rather than a fixed stride, keep the sample from aliasing with periodic input; see
-/// [`SamplePlan::subsample`]. Values that share a row tend to share a precision, so a short run
-/// costs little breadth, and eight of them spread over the input see eight regions of the column.
 const SAMPLE_BLOCK: usize = 8;
 
 /// The number of values encoded per chunk.
@@ -183,9 +173,7 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
 
     /// Finds the exponent pair with the smallest estimated encoded size.
     ///
-    /// Inputs longer than a few dozen values are sampled rather than scanned in full, as evenly
-    /// spread contiguous runs of values, since the number of decimal digits a column uses is a
-    /// property of the column rather than of any one value.
+    /// Large inputs are sampled in evenly spread contiguous runs to bound search cost.
     fn find_best_exponents(values: &[Self]) -> Exponents {
         let plan = SamplePlan::subsample(values.len(), SAMPLE_SIZE, SAMPLE_BLOCK);
         let sample: Vec<Self> = plan.iter(values).copied().collect();
@@ -196,8 +184,6 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
         for e in (0..Self::MAX_EXPONENT).rev() {
             for f in 0..=e {
                 let exp = Exponents { e, f };
-                // A candidate whose exceptions alone already cost more than the best so far cannot
-                // win, or tie, so the estimate gives up on it part-way through the sample.
                 let Some(size) = estimate_encoded_size_within(&sample, exp, best_nbytes) else {
                     continue;
                 };
@@ -423,30 +409,19 @@ pub trait ALPFloat: private::Sealed + Float + Display + 'static {
     }
 }
 
-/// Bytes one exception costs: its value at full precision, plus a position.
-///
-/// In practice, patch positions are in `[0, u16::MAX]` because of how we chunk.
+// Chunking keeps patch positions within `u16`.
 const fn patch_bytes<T>() -> usize {
     size_of::<T>() + size_of::<u16>()
 }
 
-/// [`ALPFloat::estimate_encoded_size_for_exponents`], giving up as soon as the exceptions alone
-/// cost more than `limit` bytes.
-///
-/// Returns `None` for a candidate that cannot come in at or under `limit`, so a search can pass
-/// its best size so far and skip the rest of the sample for every pair that has already lost.
-/// The bound is exact: every exception adds [`patch_bytes`] to the final estimate, so a running
-/// exception cost above `limit` puts the total above it too, and a candidate that is not
-/// abandoned is scored exactly as the unbounded estimate would.
+/// Returns the exact estimate, or `None` once exception costs alone exceed `limit`.
+/// Candidates that could tie the limit must still be scored for exponent tie-breaking.
 fn estimate_encoded_size_within<T: ALPFloat>(
     values: &[T],
     exponents: Exponents,
     limit: usize,
 ) -> Option<usize> {
-    // `kept` is the (min, max) over values that round-trip exactly (kept inline by `encode`);
-    // `all` is the (min, max) over every encoded value. `encode` fills patched slots in-range,
-    // so its emitted range is `kept`, except with all values patched (no fill), where `all`
-    // wins.
+    // `encode` fills patched slots within the kept range, unless every value is patched.
     let mut kept: Option<(T::ALPInt, T::ALPInt)> = None;
     let mut all: Option<(T::ALPInt, T::ALPInt)> = None;
     let mut patch_count = 0usize;
@@ -741,7 +716,6 @@ mod tests {
         check_estimate_matches::<f32>(&[1.0 / 3.0; 8]);
     }
 
-    /// A small linear congruential generator, so the tests need no extra dependencies.
     struct Lcg(u64);
 
     impl Lcg {
@@ -758,14 +732,13 @@ mod tests {
             (self.0 >> 11) as f64 / (1u64 << 53) as f64
         }
 
-        /// A value with `digits` decimal places, below `magnitude`.
         fn next_decimal(&mut self, magnitude: f64, digits: i32) -> f64 {
             let scale = 10f64.powi(digits);
             (self.next_unit() * magnitude * scale).round() / scale
         }
     }
 
-    /// The search, without the bound that lets it abandon losing candidates early.
+    /// Exhaustive search without early pruning.
     fn reference_search<T: ALPFloat>(sample: &[T]) -> Exponents {
         let mut best_exp = Exponents { e: 0, f: 0 };
         let mut best_nbytes = T::estimate_encoded_size_for_exponents(sample, best_exp);
@@ -784,8 +757,6 @@ mod tests {
         best_exp
     }
 
-    // Abandoning candidates part-way must not change what the search picks: the bound is a proof
-    // that the candidate has lost, not a heuristic.
     #[test]
     fn bounded_search_matches_unbounded_search() {
         let mut rng = Lcg::new();
@@ -823,7 +794,6 @@ mod tests {
                     estimate_encoded_size_within(&sample, exp, usize::MAX),
                     Some(size)
                 );
-                // Too tight a bound gives up exactly when the exceptions alone exceed it.
                 let patches = (size - {
                     let (_, encoded, ..) = f64::encode(&sample, Some(exp));
                     f64::estimate_encoded_size(&encoded, &[])
@@ -842,10 +812,7 @@ mod tests {
         }
     }
 
-    // A stride of `len / SAMPLE_SIZE` lands on one phase of any input whose period divides it.
-    // Here every value at such a position is an integer while the rest have five decimals, so a
-    // strided sample would see only integers and pick no scaling at all, leaving the rest of the
-    // column as exceptions. Runs see the decimals.
+    // A strided sample would see only integers and miss the five-decimal values.
     #[test]
     fn sampling_is_robust_to_periodic_input() {
         let mut rng = Lcg::new();
@@ -866,8 +833,6 @@ mod tests {
         }
     }
 
-    // Sampling must not cost compression on data whose precision is uniform throughout, which is
-    // the case classic ALP is for.
     #[test]
     fn sampled_search_matches_full_scan_on_uniform_data() {
         let mut rng = Lcg::new();
@@ -882,8 +847,7 @@ mod tests {
                 full.e - full.f,
                 "{digits} digits: sampled {sampled}, full scan {full}"
             );
-            // A few decimals do not survive the two multiplications at any pair, so compare
-            // exception counts rather than demanding none.
+            // Rounding can still produce exceptions, so compare against the full scan.
             let (_, _, sampled_patches, ..) = encode(&values, Some(sampled));
             let (_, _, full_patches, ..) = encode(&values, Some(full));
             assert!(

--- a/src/alp_rd/mod.rs
+++ b/src/alp_rd/mod.rs
@@ -1,8 +1,9 @@
 use crate::Exceptions;
+use crate::sample::SamplePlan;
 use fastlanes::BitPacking;
 use num_traits::{Float, One, PrimInt, Unsigned, Zero};
 use std::marker::PhantomData;
-use std::ops::{Range, Shl, Shr};
+use std::ops::{Shl, Shr};
 
 /// Returns the number of bits required to represent `value`, with a minimum of one.
 #[inline]
@@ -32,13 +33,11 @@ const MAX_SAMPLE: usize = 4096;
 
 /// Length of each contiguous run of values taken by [`SamplePlan::subsample`].
 ///
-/// Runs, rather than a fixed stride, are what make subsampling safe. A stride of `len / MAX_SAMPLE`
-/// aliases with any periodicity in the input — interleaved coordinate or embedding columns,
-/// round-robin sensor readings — and a strided sample then observes only one phase of the data.
-/// Measured on interleaved values of two very different magnitudes, striding chose cut points 2.9
-/// to 10.7 bits/value worse than a full scan, with 15-40% of the input left un-encodable. Runs come
-/// within 0.03 bits/value of a full scan on the same input, and touch far fewer cache lines than a
-/// wide stride. See `test_subsample_matches_full_scan_on_periodic_data`.
+/// Runs, rather than a fixed stride, are what make subsampling safe against periodic input; see
+/// [`SamplePlan::subsample`]. Measured on interleaved values of two very different magnitudes,
+/// striding chose cut points 2.9 to 10.7 bits/value worse than a full scan, with 15-40% of the
+/// input left un-encodable. Runs of this length come within 0.03 bits/value of a full scan on the
+/// same input. See `test_subsample_matches_full_scan_on_periodic_data`.
 const SAMPLE_BLOCK: usize = 64;
 
 mod private {
@@ -681,69 +680,6 @@ pub fn alp_rd_combine_codes_inplace<T: ALPRDFloat>(
     }
 }
 
-/// Which elements of the input to examine when searching for the best cut point.
-///
-/// A plan is a set of disjoint, ascending, contiguous ranges. It is built once and shared by every
-/// candidate cut point, so the trials all score the same values and their estimates stay
-/// comparable.
-#[derive(Debug)]
-struct SamplePlan {
-    ranges: Vec<Range<usize>>,
-    count: usize,
-}
-
-impl SamplePlan {
-    /// A plan covering every element of a `len`-element input.
-    fn full(len: usize) -> Self {
-        let mut ranges = Vec::new();
-        if len > 0 {
-            ranges.push(0..len);
-        }
-        Self { ranges, count: len }
-    }
-
-    /// A plan covering at most `max_sample` elements of a `len`-element input, as evenly spread
-    /// contiguous runs of `block` values.
-    ///
-    /// Falls back to [`Self::full`] for inputs already at or below `max_sample`.
-    fn subsample(len: usize, max_sample: usize, block: usize) -> Self {
-        let block = block.clamp(1, max_sample.max(1));
-        if len <= max_sample {
-            return Self::full(len);
-        }
-
-        let n_blocks = (max_sample / block).max(1);
-        // `len > max_sample >= n_blocks * block` puts the spacing at `block` or more, so the runs
-        // stay disjoint, and the last one starts at `len - block` or earlier, so all are in bounds.
-        // Multiplying the floored spacing (rather than dividing a product) keeps this from
-        // overflowing on absurd lengths.
-        let spacing = if n_blocks > 1 {
-            (len - block) / (n_blocks - 1)
-        } else {
-            0
-        };
-        let ranges: Vec<Range<usize>> = (0..n_blocks)
-            .map(|i| {
-                let start = i * spacing;
-                start..start + block
-            })
-            .collect();
-
-        let count = ranges.iter().map(Range::len).sum();
-        Self { ranges, count }
-    }
-
-    /// The ranges to sample, ascending and disjoint.
-    fn ranges(&self) -> &[Range<usize>] {
-        &self.ranges
-    }
-
-    /// Total number of elements the plan visits.
-    fn count(&self) -> usize {
-        self.count
-    }
-}
-
 /// Finds the best "cut point" for a set of floating-point values, i.e. the one with the lowest
 /// estimated compressed size, considering only the elements `plan` selects.
 ///
@@ -791,15 +727,9 @@ fn find_best_dictionary<T: ALPRDFloat>(samples: &[T], plan: &SamplePlan) -> ALPR
 /// candidate cut point.
 fn gather_patterns<T: ALPRDFloat>(samples: &[T], plan: &SamplePlan) -> Vec<u16> {
     let shift = (T::BITS - CUT_LIMIT) as u32;
-    let mut patterns = Vec::with_capacity(plan.count());
-    for range in plan.ranges() {
-        patterns.extend(
-            samples[range.start..range.end]
-                .iter()
-                .map(|value| <T as ALPRDFloat>::to_u16(T::to_bits(*value).shr(shift as _))),
-        );
-    }
-    patterns
+    plan.iter(samples)
+        .map(|value| <T as ALPRDFloat>::to_u16(T::to_bits(*value).shr(shift as _)))
+        .collect()
 }
 
 /// Sorts 16-bit keys with a two-digit least-significant-digit radix sort.
@@ -957,9 +887,10 @@ impl ALPRDDictionary {
 #[cfg(test)]
 mod test {
     use super::{
-        ALPRDFloat, CUT_LIMIT, MAX_SAMPLE, REVERSE_SLOTS, ReverseDict, SAMPLE_BLOCK, SamplePlan,
+        ALPRDFloat, CUT_LIMIT, MAX_SAMPLE, REVERSE_SLOTS, ReverseDict, SAMPLE_BLOCK,
         estimate_compression_size, find_best_dictionary, lanes_code, window_code,
     };
+    use crate::sample::SamplePlan;
     use crate::{
         MAX_DICT_SIZE, RDEncoder, alp_rd_apply_patches, alp_rd_combine_codes_inplace,
         alp_rd_combine_inplace, alp_rd_decode, alp_rd_dict_decode_inplace, bit_width,
@@ -1378,54 +1309,6 @@ mod test {
     fn test_from_parts_rejects_oversized_dictionary() {
         // A larger dictionary needs codes wider than the decoder's fast path masks for.
         RDEncoder::from_parts(52, vec![0u16; MAX_DICT_SIZE as usize + 1]);
-    }
-
-    #[test]
-    fn test_sample_plan_covers_short_inputs_fully() {
-        for len in [0usize, 1, 63, 64, 4095, MAX_SAMPLE] {
-            let plan = SamplePlan::subsample(len, MAX_SAMPLE, SAMPLE_BLOCK);
-            assert_eq!(plan.count(), len, "short inputs must be scanned in full");
-            let covered: usize = plan.ranges().iter().map(|r| r.len()).sum();
-            assert_eq!(covered, len);
-        }
-    }
-
-    #[test]
-    fn test_sample_plan_ranges_are_in_bounds_and_disjoint() {
-        // Includes lengths that are and are not multiples of the block and sample sizes.
-        for len in [
-            MAX_SAMPLE + 1,
-            2 * MAX_SAMPLE,
-            3 * MAX_SAMPLE + 1,
-            100_003,
-            1 << 20,
-        ] {
-            let plan = SamplePlan::subsample(len, MAX_SAMPLE, SAMPLE_BLOCK);
-            assert!(
-                plan.count() <= MAX_SAMPLE,
-                "subsampling must honour the MAX_SAMPLE budget for len {len}"
-            );
-            assert_eq!(
-                plan.count(),
-                plan.ranges().iter().map(|r| r.len()).sum::<usize>()
-            );
-
-            let mut prev_end = 0;
-            for range in plan.ranges() {
-                assert!(
-                    range.start >= prev_end,
-                    "ranges must be ascending, disjoint"
-                );
-                assert!(
-                    range.end <= len,
-                    "range {}..{} exceeds {len}",
-                    range.start,
-                    range.end
-                );
-                prev_end = range.end;
-            }
-            assert!(!plan.ranges().is_empty());
-        }
     }
 
     /// Subsampling must not cost compression on data whose distribution is uniform throughout,

--- a/src/alp_rd/mod.rs
+++ b/src/alp_rd/mod.rs
@@ -32,12 +32,6 @@ pub const MAX_DICT_SIZE: u8 = 8;
 const MAX_SAMPLE: usize = 4096;
 
 /// Length of each contiguous run of values taken by [`SamplePlan::subsample`].
-///
-/// Runs, rather than a fixed stride, are what make subsampling safe against periodic input; see
-/// [`SamplePlan::subsample`]. Measured on interleaved values of two very different magnitudes,
-/// striding chose cut points 2.9 to 10.7 bits/value worse than a full scan, with 15-40% of the
-/// input left un-encodable. Runs of this length come within 0.03 bits/value of a full scan on the
-/// same input. See `test_subsample_matches_full_scan_on_periodic_data`.
 const SAMPLE_BLOCK: usize = 64;
 
 mod private {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,7 @@ pub use alp_rd::*;
 
 mod alp;
 mod alp_rd;
+mod sample;
 
 // Runs the README's examples as doctests, so they cannot drift from the API they demonstrate.
 #[cfg(doctest)]

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -1,0 +1,176 @@
+//! Subsampling shared by the two encoders' parameter searches.
+//!
+//! Both searches look at a bounded number of values, since the property they are after — how
+//! many decimal digits a column uses, or which leading bits its values share — belongs to the
+//! column rather than to any one value. This module decides which values they look at.
+
+use std::ops::Range;
+
+/// Which elements of an input a parameter search examines.
+///
+/// A plan is a set of disjoint, ascending, contiguous ranges. It is built once and shared by every
+/// candidate the search tries, so the trials all score the same values and their estimates stay
+/// comparable.
+#[derive(Debug)]
+pub(crate) struct SamplePlan {
+    ranges: Vec<Range<usize>>,
+    count: usize,
+}
+
+impl SamplePlan {
+    /// A plan covering every element of a `len`-element input.
+    pub(crate) fn full(len: usize) -> Self {
+        let mut ranges = Vec::new();
+        if len > 0 {
+            ranges.push(0..len);
+        }
+        Self { ranges, count: len }
+    }
+
+    /// A plan covering at most `max_sample` elements of a `len`-element input, as evenly spread
+    /// contiguous runs of `block` values.
+    ///
+    /// Runs, rather than a fixed stride, are what make subsampling safe. A stride of
+    /// `len / max_sample` aliases with any periodicity in the input — interleaved coordinate or
+    /// embedding columns, round-robin sensor readings, a header value every so many rows — and a
+    /// strided sample then observes only one phase of the data. A run sees every phase of any
+    /// period up to its length, and touches far fewer cache lines than a wide stride.
+    ///
+    /// Falls back to [`Self::full`] for inputs already at or below `max_sample`.
+    pub(crate) fn subsample(len: usize, max_sample: usize, block: usize) -> Self {
+        let block = block.clamp(1, max_sample.max(1));
+        if len <= max_sample {
+            return Self::full(len);
+        }
+
+        let n_blocks = (max_sample / block).max(1);
+        // `len > max_sample >= n_blocks * block` puts the spacing at `block` or more, so the runs
+        // stay disjoint, and the last one starts at `len - block` or earlier, so all are in bounds.
+        // Multiplying the floored spacing (rather than dividing a product) keeps this from
+        // overflowing on absurd lengths.
+        let spacing = if n_blocks > 1 {
+            (len - block) / (n_blocks - 1)
+        } else {
+            0
+        };
+        let ranges: Vec<Range<usize>> = (0..n_blocks)
+            .map(|i| {
+                let start = i * spacing;
+                start..start + block
+            })
+            .collect();
+
+        let count = ranges.iter().map(Range::len).sum();
+        Self { ranges, count }
+    }
+
+    /// The ranges to sample, ascending and disjoint.
+    #[cfg(test)]
+    pub(crate) fn ranges(&self) -> &[Range<usize>] {
+        &self.ranges
+    }
+
+    /// Total number of elements the plan visits.
+    pub(crate) fn count(&self) -> usize {
+        self.count
+    }
+
+    /// The elements of `values` the plan selects, in input order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the plan was built for a longer input than `values`.
+    pub(crate) fn iter<'a, T>(&'a self, values: &'a [T]) -> impl Iterator<Item = &'a T> + 'a {
+        self.ranges
+            .iter()
+            .flat_map(move |range| values[range.start..range.end].iter())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::SamplePlan;
+
+    const MAX_SAMPLE: usize = 4096;
+    const BLOCK: usize = 64;
+
+    #[test]
+    fn test_sample_plan_covers_short_inputs_fully() {
+        for len in [0usize, 1, 63, 64, 4095, MAX_SAMPLE] {
+            let plan = SamplePlan::subsample(len, MAX_SAMPLE, BLOCK);
+            assert_eq!(plan.count(), len, "short inputs must be scanned in full");
+            let covered: usize = plan.ranges().iter().map(|r| r.len()).sum();
+            assert_eq!(covered, len);
+        }
+    }
+
+    #[test]
+    fn test_sample_plan_ranges_are_in_bounds_and_disjoint() {
+        // Includes lengths that are and are not multiples of the block and sample sizes, and a
+        // budget too small to hold more than one block.
+        for (max_sample, block) in [(MAX_SAMPLE, BLOCK), (64, 8), (32, 8), (8, 8), (7, 8)] {
+            for len in [
+                max_sample + 1,
+                2 * max_sample,
+                3 * max_sample + 1,
+                100_003,
+                1 << 20,
+            ] {
+                let plan = SamplePlan::subsample(len, max_sample, block);
+                assert!(
+                    plan.count() <= max_sample,
+                    "subsampling must honour the budget of {max_sample} for len {len}"
+                );
+                assert_eq!(
+                    plan.count(),
+                    plan.ranges().iter().map(|r| r.len()).sum::<usize>()
+                );
+
+                let mut prev_end = 0;
+                for range in plan.ranges() {
+                    assert!(
+                        range.start >= prev_end,
+                        "ranges must be ascending, disjoint"
+                    );
+                    assert!(
+                        range.end <= len,
+                        "range {}..{} exceeds {len}",
+                        range.start,
+                        range.end
+                    );
+                    prev_end = range.end;
+                }
+                assert!(!plan.ranges().is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn test_sample_plan_spans_the_input() {
+        // The first run starts at the front and the last one ends at the back, so the sample spans
+        // the column rather than its head.
+        let len = 100_003;
+        let plan = SamplePlan::subsample(len, 64, 8);
+        assert_eq!(plan.ranges().len(), 8);
+        assert_eq!(plan.ranges()[0].start, 0);
+        let last = plan.ranges().last().expect("eight ranges");
+        assert!(last.end > len - 8, "last run {last:?} should reach the end");
+    }
+
+    #[test]
+    fn test_iter_visits_the_planned_elements_in_order() {
+        let values: Vec<usize> = (0..1000).collect();
+        let plan = SamplePlan::subsample(values.len(), 32, 8);
+        let sampled: Vec<usize> = plan.iter(&values).copied().collect();
+        assert_eq!(sampled.len(), plan.count());
+
+        let expected: Vec<usize> = plan.ranges().iter().flat_map(Clone::clone).collect();
+        assert_eq!(sampled, expected);
+
+        let full: Vec<usize> = SamplePlan::full(values.len())
+            .iter(&values)
+            .copied()
+            .collect();
+        assert_eq!(full, values);
+    }
+}

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -1,16 +1,8 @@
 //! Subsampling shared by the two encoders' parameter searches.
-//!
-//! Both searches look at a bounded number of values, since the property they are after — how
-//! many decimal digits a column uses, or which leading bits its values share — belongs to the
-//! column rather than to any one value. This module decides which values they look at.
 
 use std::ops::Range;
 
-/// Which elements of an input a parameter search examines.
-///
-/// A plan is a set of disjoint, ascending, contiguous ranges. It is built once and shared by every
-/// candidate the search tries, so the trials all score the same values and their estimates stay
-/// comparable.
+/// Ascending, disjoint ranges reused by every candidate in a parameter search.
 #[derive(Debug)]
 pub(crate) struct SamplePlan {
     ranges: Vec<Range<usize>>,
@@ -18,7 +10,6 @@ pub(crate) struct SamplePlan {
 }
 
 impl SamplePlan {
-    /// A plan covering every element of a `len`-element input.
     pub(crate) fn full(len: usize) -> Self {
         let mut ranges = Vec::new();
         if len > 0 {
@@ -30,11 +21,8 @@ impl SamplePlan {
     /// A plan covering at most `max_sample` elements of a `len`-element input, as evenly spread
     /// contiguous runs of `block` values.
     ///
-    /// Runs, rather than a fixed stride, are what make subsampling safe. A stride of
-    /// `len / max_sample` aliases with any periodicity in the input — interleaved coordinate or
-    /// embedding columns, round-robin sensor readings, a header value every so many rows — and a
-    /// strided sample then observes only one phase of the data. A run sees every phase of any
-    /// period up to its length, and touches far fewer cache lines than a wide stride.
+    /// A fixed stride can repeatedly sample one phase of periodic input. Runs cover every phase
+    /// of periods up to `block` and improve cache locality.
     ///
     /// Falls back to [`Self::full`] for inputs already at or below `max_sample`.
     pub(crate) fn subsample(len: usize, max_sample: usize, block: usize) -> Self {
@@ -44,10 +32,7 @@ impl SamplePlan {
         }
 
         let n_blocks = (max_sample / block).max(1);
-        // `len > max_sample >= n_blocks * block` puts the spacing at `block` or more, so the runs
-        // stay disjoint, and the last one starts at `len - block` or earlier, so all are in bounds.
-        // Multiplying the floored spacing (rather than dividing a product) keeps this from
-        // overflowing on absurd lengths.
+        // Spacing keeps runs disjoint and in bounds; dividing before multiplying avoids overflow.
         let spacing = if n_blocks > 1 {
             (len - block) / (n_blocks - 1)
         } else {
@@ -64,22 +49,16 @@ impl SamplePlan {
         Self { ranges, count }
     }
 
-    /// The ranges to sample, ascending and disjoint.
     #[cfg(test)]
     pub(crate) fn ranges(&self) -> &[Range<usize>] {
         &self.ranges
     }
 
-    /// Total number of elements the plan visits.
     pub(crate) fn count(&self) -> usize {
         self.count
     }
 
-    /// The elements of `values` the plan selects, in input order.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the plan was built for a longer input than `values`.
+    /// Selected elements in input order. Panics if a sampled range exceeds `values`.
     pub(crate) fn iter<'a, T>(&'a self, values: &'a [T]) -> impl Iterator<Item = &'a T> + 'a {
         self.ranges
             .iter()
@@ -106,8 +85,6 @@ mod test {
 
     #[test]
     fn test_sample_plan_ranges_are_in_bounds_and_disjoint() {
-        // Includes lengths that are and are not multiples of the block and sample sizes, and a
-        // budget too small to hold more than one block.
         for (max_sample, block) in [(MAX_SAMPLE, BLOCK), (64, 8), (32, 8), (8, 8), (7, 8)] {
             for len in [
                 max_sample + 1,
@@ -147,8 +124,6 @@ mod test {
 
     #[test]
     fn test_sample_plan_spans_the_input() {
-        // The first run starts at the front and the last one ends at the back, so the sample spans
-        // the column rather than its head.
         let len = 100_003;
         let plan = SamplePlan::subsample(len, 64, 8);
         assert_eq!(plan.ranges().len(), 8);


### PR DESCRIPTION
Extract alp-rd sampling logic and share it with ALP. Instead of single 32 value stride we sample 8 runs of 8 values.

Also early terminate calculating compressed size if exception count exceeds existing best size